### PR TITLE
handle conversion of label columns

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -87,7 +87,8 @@ def convert_sqlalchemy_type(type, column, registry=None):
 @convert_sqlalchemy_type.register(postgresql.ENUM)
 @convert_sqlalchemy_type.register(postgresql.UUID)
 def convert_column_to_string(type, column, registry=None):
-    return String(description=column.doc, required=not(column.nullable))
+    return String(description=getattr(column, 'doc', None),
+                  required=not(getattr(column, 'nullable', True)))
 
 
 @convert_sqlalchemy_type.register(types.SmallInteger)

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -1,8 +1,9 @@
 from py.test import raises
-from sqlalchemy import Column, Table, types
+from sqlalchemy import Column, Table, case, types
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import composite
+from sqlalchemy.sql.elements import Label
 from sqlalchemy_utils import ChoiceType, ScalarListType
 
 import graphene
@@ -104,6 +105,12 @@ def test_should_float_convert_float():
 
 def test_should_numeric_convert_float():
     assert_column_conversion(types.Numeric(), graphene.Float)
+
+
+def test_should_label_convert_string():
+    label = Label('label_test', case([], else_="foo"), type_=types.Unicode())
+    graphene_type = convert_sqlalchemy_column(label)
+    assert isinstance(graphene_type, graphene.String)
 
 
 def test_should_choice_convert_enum():


### PR DESCRIPTION
when using sqlalchemy expressions as columns, the selectable is a Label which may be converted, however the Label type may not have `doc` or `nullable` attributes. This change uses `getattr` to try to retrieve them.