### PR TITLE
allow abstract subclasses of SQLAlchemyObjectType

### DIFF
--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -74,3 +74,15 @@ def test_object_type():
     assert issubclass(Human, ObjectType)
     assert list(Human._meta.fields.keys()) == ['id', 'headline', 'reporter_id', 'reporter', 'pub_date']
     assert is_node(Human)
+
+
+def test_abstract_subclass():
+    registry = Registry()
+
+    class AbstractSubclass(SQLAlchemyObjectType):
+        class Meta:
+            registry = registry
+            abstract = True
+
+    assert issubclass(AbstractSubclass, SQLAlchemyObjectType)
+    assert len(registry._registry) == 0

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -69,7 +69,8 @@ class SQLAlchemyObjectTypeMeta(ObjectTypeMeta):
     def __new__(cls, name, bases, attrs):
         # Also ensure initialization is only performed for subclasses of Model
         # (excluding Model class itself).
-        if not is_base_type(bases, SQLAlchemyObjectTypeMeta):
+        if not is_base_type(bases, SQLAlchemyObjectTypeMeta) or \
+                ('Meta' in attrs and getattr(attrs['Meta'], 'abstract', False)):
             return type.__new__(cls, name, bases, attrs)
 
         options = Options(


### PR DESCRIPTION
this allows `SQLAlchemyObjectType` to be subclassed so you can provide common functionality. My use case is to override `resolve_id`, but this could/should be extended to allow the abstract subclass to provide field declarations and perhaps common meta options (interfaces, etc)
