### PR TITLE
graphene type DateTime should used for sqlalchemy type DateTime

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -93,11 +93,13 @@ def convert_column_to_string(type, column, registry=None):
     return String(description=getattr(column, 'doc', None),
                   required=not(getattr(column, 'nullable', True)))
 
+
 @convert_sqlalchemy_type.register(types.DateTime)
 def convert_column_to_datetime(type, column, registry=None):
     from graphene.types.datetime import DateTime
     return DateTime(description=getattr(column, 'doc', None),
-                  required=not(getattr(column, 'nullable', True)))
+                    required=not(getattr(column, 'nullable', True)))
+
 
 @convert_sqlalchemy_type.register(types.SmallInteger)
 @convert_sqlalchemy_type.register(types.BigInteger)

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -81,7 +81,6 @@ def convert_sqlalchemy_type(type, column, registry=None):
 
 
 @convert_sqlalchemy_type.register(types.Date)
-@convert_sqlalchemy_type.register(types.DateTime)
 @convert_sqlalchemy_type.register(types.Time)
 @convert_sqlalchemy_type.register(types.String)
 @convert_sqlalchemy_type.register(types.Text)
@@ -94,6 +93,11 @@ def convert_column_to_string(type, column, registry=None):
     return String(description=getattr(column, 'doc', None),
                   required=not(getattr(column, 'nullable', True)))
 
+@convert_sqlalchemy_type.register(types.DateTime)
+def convert_column_to_datetime(type, column, registry=None):
+    from graphene.types.datetime import DateTime
+    return DateTime(description=getattr(column, 'doc', None),
+                  required=not(getattr(column, 'nullable', True)))
 
 @convert_sqlalchemy_type.register(types.SmallInteger)
 @convert_sqlalchemy_type.register(types.BigInteger)

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -8,6 +8,7 @@ from sqlalchemy_utils import ChoiceType, JSONType, ScalarListType
 
 import graphene
 from graphene.relay import Node
+from graphene.types.datetime import DateTime
 from graphene.types.json import JSONString
 
 from ..converter import (convert_sqlalchemy_column,
@@ -52,7 +53,7 @@ def test_should_date_convert_string():
 
 
 def test_should_datetime_convert_string():
-    assert_column_conversion(types.DateTime(), graphene.DateTime)
+    assert_column_conversion(types.DateTime(), DateTime)
 
 
 def test_should_time_convert_string():

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -52,7 +52,7 @@ def test_should_date_convert_string():
 
 
 def test_should_datetime_convert_string():
-    assert_column_conversion(types.DateTime(), graphene.String)
+    assert_column_conversion(types.DateTime(), graphene.DateTime)
 
 
 def test_should_time_convert_string():

--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
         'graphene>=1.0',
         'SQLAlchemy',
         'singledispatch>=3.4.0.3',
+        'iso8601',
     ],
     tests_require=[
         'pytest>=2.7.2',


### PR DESCRIPTION
Currently, datetime is converted to string.
The impact is, that the value is always formatted according to the local date and time representation and not, like defined by the standard, in the iso-format.
This pull request solves the problem