### PR TITLE
sqlalchemy-type Biginteger cannot be handled as graphql-type integer because it is limited to 32 bit

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -95,7 +95,7 @@ def convert_column_to_string(type, column, registry=None):
 
 
 @convert_sqlalchemy_type.register(types.SmallInteger)
-@convert_sqlalchemy_type.register(types.BigInteger)
+#@convert_sqlalchemy_type.register(types.BigInteger)
 @convert_sqlalchemy_type.register(types.Integer)
 def convert_column_to_int_or_id(type, column, registry=None):
     if column.primary_key:
@@ -111,6 +111,7 @@ def convert_column_to_boolean(type, column, registry=None):
 
 @convert_sqlalchemy_type.register(types.Float)
 @convert_sqlalchemy_type.register(types.Numeric)
+@convert_sqlalchemy_type.register(types.BigInteger)
 def convert_column_to_float(type, column, registry=None):
     return Float(description=column.doc, required=not(column.nullable))
 

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -95,7 +95,6 @@ def convert_column_to_string(type, column, registry=None):
 
 
 @convert_sqlalchemy_type.register(types.SmallInteger)
-#@convert_sqlalchemy_type.register(types.BigInteger)
 @convert_sqlalchemy_type.register(types.Integer)
 def convert_column_to_int_or_id(type, column, registry=None):
     if column.primary_key:

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -84,7 +84,7 @@ def test_should_small_integer_convert_int():
 
 
 def test_should_big_integer_convert_int():
-    assert_column_conversion(types.BigInteger(), graphene.Int)
+    assert_column_conversion(types.BigInteger(), graphene.Float)
 
 
 def test_should_integer_convert_int():


### PR DESCRIPTION
According to the standard, the graphql-int-type is [limited to 32 bit](https://facebook.github.io/graphql/#sec-Int).
But BigInteger in sqlalchemy can contain greater numeric values...

I changed the converter in order to convert BigInteger to float instead of int and this seems to work without any drawback
