### PR TITLE
Create SQLAlchemyConnectionField through a factory method.

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -8,7 +8,7 @@ from graphene import (ID, Boolean, Dynamic, Enum, Field, Float, Int, List,
 from graphene.relay import is_node
 from graphene.types.json import JSONString
 
-from .fields import SQLAlchemyConnectionField
+from .fields import createConnectionField
 
 try:
     from sqlalchemy_utils import ChoiceType, JSONType, ScalarListType
@@ -36,7 +36,7 @@ def convert_sqlalchemy_relationship(relationship, registry):
         elif (direction == interfaces.ONETOMANY or
               direction == interfaces.MANYTOMANY):
             if is_node(_type):
-                return SQLAlchemyConnectionField(_type)
+                return createConnectionField(_type)
             return Field(List(_type))
 
     return Dynamic(dynamic_type)

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -41,3 +41,11 @@ class SQLAlchemyConnectionField(ConnectionField):
 
     def get_resolver(self, parent_resolver):
         return partial(self.connection_resolver, parent_resolver, self.type, self.model)
+
+__connectionFactory = SQLAlchemyConnectionField
+def createConnectionField(_type):
+    return __connectionFactory(_type)
+
+def registerConnectionFieldFactory(factoryMethod):
+    global __connectionFactory
+    __connectionFactory = factoryMethod

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -42,9 +42,13 @@ class SQLAlchemyConnectionField(ConnectionField):
     def get_resolver(self, parent_resolver):
         return partial(self.connection_resolver, parent_resolver, self.type, self.model)
 
+
 __connectionFactory = SQLAlchemyConnectionField
+
+
 def createConnectionField(_type):
     return __connectionFactory(_type)
+
 
 def registerConnectionFieldFactory(factoryMethod):
     global __connectionFactory


### PR DESCRIPTION
Overriding the constructor-method gives the user the possibility to enhance the standard implementation of connection fields. (If you want to add filtering/sorting for example)