### PR TITLE
Adding iterable and length to SQLAlchemyConnectionField

### DIFF
--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -1,16 +1,14 @@
 from functools import partial
 
-from sqlalchemy.orm.query import Query
-
 from graphene.relay import ConnectionField
 from graphene.relay.connection import PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
+from sqlalchemy.orm.query import Query
 
 from .utils import get_query
 
 
 class SQLAlchemyConnectionField(ConnectionField):
-
     @property
     def model(self):
         return self.type._meta.node._meta.model
@@ -28,7 +26,7 @@ class SQLAlchemyConnectionField(ConnectionField):
             _len = iterable.count()
         else:
             _len = len(iterable)
-        return connection_from_list_slice(
+        connection = connection_from_list_slice(
             iterable,
             args,
             slice_start=0,
@@ -38,6 +36,9 @@ class SQLAlchemyConnectionField(ConnectionField):
             pageinfo_type=PageInfo,
             edge_type=connection.Edge,
         )
+        connection.iterable = iterable
+        connection.length = _len
+        return connection
 
     def get_resolver(self, parent_resolver):
         return partial(self.connection_resolver, parent_resolver, self.type, self.model)

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -1,14 +1,16 @@
 from functools import partial
 
+from sqlalchemy.orm.query import Query
+
 from graphene.relay import ConnectionField
 from graphene.relay.connection import PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
-from sqlalchemy.orm.query import Query
 
 from .utils import get_query
 
 
 class SQLAlchemyConnectionField(ConnectionField):
+
     @property
     def model(self):
         return self.type._meta.node._meta.model


### PR DESCRIPTION
It is currently difficult to resolve a total_count field with the SQLAlchemy graphene library.

The example from [swapi](https://github.com/graphql-python/swapi-graphene/blob/master/starwars/schema.py#L18-L22) has a nice little implementation that does not work here since unlike Django, the SQLAlchemyConnectionField does not set neither length nor iterable on the connection returned.

This PR brings length and iterable to SQLAlchemyConnectionField to match DjangoConnectionField.
