### PR TITLE
Create SQLAlchemyConnectionField through a factory method

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -8,7 +8,7 @@ from graphene import (ID, Boolean, Dynamic, Enum, Field, Float, Int, List,
 from graphene.relay import is_node
 from graphene.types.json import JSONString
 
-from .fields import SQLAlchemyConnectionField
+from .fields import createConnectionField
 
 try:
     from sqlalchemy_utils import ChoiceType, JSONType, ScalarListType
@@ -36,7 +36,7 @@ def convert_sqlalchemy_relationship(relationship, registry):
         elif (direction == interfaces.ONETOMANY or
               direction == interfaces.MANYTOMANY):
             if is_node(_type):
-                return SQLAlchemyConnectionField(_type)
+                return createConnectionField(_type)
             return Field(List(_type))
 
     return Dynamic(dynamic_type)

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -41,3 +41,11 @@ class SQLAlchemyConnectionField(ConnectionField):
 
     def get_resolver(self, parent_resolver):
         return partial(self.connection_resolver, parent_resolver, self.type, self.model)
+
+__connectionFactory = SQLAlchemyConnectionField
+def createConnectionField(_type):
+    return __connectionFactory(_type)
+
+def registerConnectionFieldFactory(factoryMethod):
+    global __connectionFactory
+    __connectionFactory = factoryMethod

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -53,3 +53,8 @@ def createConnectionField(_type):
 def registerConnectionFieldFactory(factoryMethod):
     global __connectionFactory
     __connectionFactory = factoryMethod
+
+
+def unregisterConnectionFieldFactory():
+    global __connectionFactory
+    __connectionFactory = SQLAlchemyConnectionField

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -42,9 +42,13 @@ class SQLAlchemyConnectionField(ConnectionField):
     def get_resolver(self, parent_resolver):
         return partial(self.connection_resolver, parent_resolver, self.type, self.model)
 
+
 __connectionFactory = SQLAlchemyConnectionField
+
+
 def createConnectionField(_type):
     return __connectionFactory(_type)
+
 
 def registerConnectionFieldFactory(factoryMethod):
     global __connectionFactory

--- a/graphene_sqlalchemy/tests/test_connectionfactory.py
+++ b/graphene_sqlalchemy/tests/test_connectionfactory.py
@@ -1,0 +1,29 @@
+from graphene_sqlalchemy.fields import SQLAlchemyConnectionField, registerConnectionFieldFactory
+import graphene
+
+def test_register():
+    class LXConnectionField(SQLAlchemyConnectionField):
+        @classmethod
+        def _applyQueryArgs(cls, model, q, args):
+            return q
+
+        @classmethod
+        def connection_resolver(cls, resolver, connection, model, root, args, context, info):
+
+            def LXResolver(root, args, context, info):
+                iterable = resolver(root, args, context, info)
+                if iterable is None:
+                    iterable = cls.get_query(model, context, info, args)
+
+                # We accept always a query here. All LX-queries can be filtered and sorted
+                iterable = cls._applyQueryArgs(model, iterable, args)
+                return iterable
+
+            return SQLAlchemyConnectionField.connection_resolver(LXResolver, connection, model, root, args, context, info)
+
+    def createLXConnectionField(table):
+        return LXConnectionField(table, filter=table.filter(), order_by=graphene.List(of_type=table.order_by))
+
+    registerConnectionFieldFactory(createLXConnectionField)
+
+    

--- a/graphene_sqlalchemy/tests/test_connectionfactory.py
+++ b/graphene_sqlalchemy/tests/test_connectionfactory.py
@@ -1,4 +1,4 @@
-from graphene_sqlalchemy.fields import SQLAlchemyConnectionField, registerConnectionFieldFactory
+from graphene_sqlalchemy.fields import SQLAlchemyConnectionField, registerConnectionFieldFactory, unregisterConnectionFieldFactory
 import graphene
 
 def test_register():
@@ -25,5 +25,4 @@ def test_register():
         return LXConnectionField(table, filter=table.filter(), order_by=graphene.List(of_type=table.order_by))
 
     registerConnectionFieldFactory(createLXConnectionField)
-
-    
+    unregisterConnectionFieldFactory()


### PR DESCRIPTION
Overriding the constructor-method gives the user the possibility to enhance the standard implementation of connection fields. (If you want to add filtering/sorting for example)