### PR TITLE
Allow subclassing of SQLAlchemyObjectType without major API changes

### DIFF
--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -6,7 +6,7 @@ class Registry(object):
         self._registry_composites = {}
 
     def register(self, cls):
-        from .types import SQLAlchemyObjectType, SQLAlchemyObjectTypeMeta
+        from .types import SQLAlchemyObjectTypeMeta
         assert issubclass(type(cls), SQLAlchemyObjectTypeMeta), (
             'Only classes of type SQLAlchemyObjectTypeMeta can be registered, ',
             'received "{}"'

--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -6,10 +6,11 @@ class Registry(object):
         self._registry_composites = {}
 
     def register(self, cls):
-        from .types import SQLAlchemyObjectType
-        assert issubclass(
-            cls, SQLAlchemyObjectType), 'Only SQLAlchemyObjectType can be registered, received "{}"'.format(
-            cls.__name__)
+        from .types import SQLAlchemyObjectType, SQLAlchemyObjectTypeMeta
+        assert issubclass(type(cls), SQLAlchemyObjectTypeMeta), (
+            'Only classes of type SQLAlchemyObjectTypeMeta can be registered, ',
+            'received "{}"'
+        ).format(cls.__name__)
         assert cls._meta.registry == self, 'Registry for a Model have to match.'
         # assert self.get_type_for_model(cls._meta.model) in [None, cls], (
         #     'SQLAlchemy model "{}" already associated with '

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -1,9 +1,10 @@
 
 from graphene import Field, Int, Interface, ObjectType
 from graphene.relay import Node, is_node
+import six
 
 from ..registry import Registry
-from ..types import SQLAlchemyObjectType
+from ..types import SQLAlchemyObjectType, SQLAlchemyObjectTypeMeta
 from .models import Article, Reporter
 
 registry = Registry()
@@ -74,3 +75,46 @@ def test_object_type():
     assert issubclass(Human, ObjectType)
     assert list(Human._meta.fields.keys()) == ['id', 'headline', 'reporter_id', 'reporter', 'pub_date']
     assert is_node(Human)
+
+
+
+# Test Custom SQLAlchemyObjectType Implementation
+class CustomSQLAlchemyObjectType(six.with_metaclass(SQLAlchemyObjectTypeMeta, ObjectType)):
+    @classmethod
+    def is_type_of(cls, root, context, info):
+        return SQLAlchemyObjectType.is_type_of(root, context, info)
+
+    @classmethod
+    def get_query(cls, context):
+        return SQLAlchemyObjectType.get_query(context)
+
+    @classmethod
+    def get_node(cls, id, context, info):
+        return SQLAlchemyObjectType.get_node(id, context, info)
+
+    @classmethod
+    def resolve_id(self, args, context, info):
+        graphene_type = info.parent_type.graphene_type
+        if is_node(graphene_type):
+            return self.__mapper__.primary_key_from_instance(self)[0]
+        return getattr(self, graphene_type._meta.id, None)
+
+
+class CustomCharacter(CustomSQLAlchemyObjectType):
+    '''Character description'''
+    class Meta:
+        model = Reporter
+        registry = registry
+
+def test_custom_objecttype_registered():
+    assert issubclass(CustomCharacter, ObjectType)
+    assert CustomCharacter._meta.model == Reporter
+    assert list(
+        CustomCharacter._meta.fields.keys()) == [
+        'id',
+        'first_name',
+        'last_name',
+        'email',
+        'pets',
+        'articles',
+        'favorite_article']

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -79,25 +79,9 @@ def test_object_type():
 
 
 # Test Custom SQLAlchemyObjectType Implementation
-class CustomSQLAlchemyObjectType(six.with_metaclass(SQLAlchemyObjectTypeMeta, ObjectType)):
-    @classmethod
-    def is_type_of(cls, root, context, info):
-        return SQLAlchemyObjectType.is_type_of(root, context, info)
-
-    @classmethod
-    def get_query(cls, context):
-        return SQLAlchemyObjectType.get_query(context)
-
-    @classmethod
-    def get_node(cls, id, context, info):
-        return SQLAlchemyObjectType.get_node(id, context, info)
-
-    @classmethod
-    def resolve_id(self, args, context, info):
-        graphene_type = info.parent_type.graphene_type
-        if is_node(graphene_type):
-            return self.__mapper__.primary_key_from_instance(self)[0]
-        return getattr(self, graphene_type._meta.id, None)
+class CustomSQLAlchemyObjectType(SQLAlchemyObjectType):
+    class Meta:
+        abstract = True
 
 
 class CustomCharacter(CustomSQLAlchemyObjectType):
@@ -105,6 +89,7 @@ class CustomCharacter(CustomSQLAlchemyObjectType):
     class Meta:
         model = Reporter
         registry = registry
+
 
 def test_custom_objecttype_registered():
     assert issubclass(CustomCharacter, ObjectType)

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -82,8 +82,14 @@ class SQLAlchemyObjectTypeMeta(ObjectTypeMeta):
             exclude_fields=(),
             id='id',
             interfaces=(),
-            registry=None
+            registry=None,
+            abstract=False,
         )
+
+        cls = ObjectTypeMeta.__new__(cls, name, bases, dict(attrs, _meta=options))
+
+        if options.abstract:
+            return cls
 
         if not options.registry:
             options.registry = get_global_registry()
@@ -95,8 +101,6 @@ class SQLAlchemyObjectTypeMeta(ObjectTypeMeta):
             'You need to pass a valid SQLAlchemy Model in '
             '{}.Meta, received "{}".'
         ).format(name, options.model)
-
-        cls = ObjectTypeMeta.__new__(cls, name, bases, dict(attrs, _meta=options))
 
         options.registry.register(cls)
 
@@ -115,6 +119,8 @@ class SQLAlchemyObjectTypeMeta(ObjectTypeMeta):
 
 
 class SQLAlchemyObjectType(six.with_metaclass(SQLAlchemyObjectTypeMeta, ObjectType)):
+    class Meta:
+        abstract = True
 
     @classmethod
     def is_type_of(cls, root, context, info):

--- a/setup.cfg
+++ b/setup.cfg
@@ -7,3 +7,20 @@ omit = */tests/*
 
 [isort]
 known_first_party=graphene,graphene_sqlalchemy
+
+[tool:pytest]
+testpaths = graphene_sqlalchemy/
+addopts =
+    -s
+    ; --cov graphene-sqlalchemy
+norecursedirs =
+    __pycache__
+    *.egg-info
+    .cache
+    .git
+    .tox
+    appdir
+    docs
+filterwarnings =
+    error
+    ignore::DeprecationWarning


### PR DESCRIPTION
This PR allows wholesale re-implementation of `SQLAlchemyObjectType` by revising the registry to ensure the classes are of type `SQLAlchemyObjectTypeMeta`, or subclassing SQLAlchemyObjectType (or a subclass thereof) by providing `abstract = True` on the subclass's Meta.

The docs have been updated to reflect this.

i.e.:
```python
from graphene_sqlalchemy import SQLAlchemyObjectType

class ActiveSQLAlchemyObjectType(SQLAlchemyObjectType):
    class Meta:
        abstract = True

    @classmethod
    def get_node(cls, id, context, info):
        return cls.get_query(context).\
            filter(and_(
                cls._meta.model.deleted_at==None,
                cls._meta.model.id==id,
            )).\
            first()

class User(ActiveSQLAlchemyObjectType):
    class Meta:
        model = UserModel

class Query(graphene.ObjectType):
    users = graphene.List(User)

    def resolve_users(self, args, context, info):
        query = User.get_query(context) # SQLAlchemy query
        return query.all()

schema = graphene.Schema(query=Query)
```