### PR TITLE
don't assume property is not nullable when no "nullable" field on property

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -28,7 +28,7 @@ def get_column_doc(column):
 
 
 def is_column_nullable(column):
-    return bool(getattr(column, 'nullable', False))
+    return bool(getattr(column, 'nullable', True))
 
 
 def convert_sqlalchemy_relationship(relationship, registry):


### PR DESCRIPTION
Most of the time, the properties set on SQLAlchemy models are the `Column` datatype. These are guaranteed to have a `nullable` attribute set of either `True` or `False`:
https://github.com/zzzeek/sqlalchemy/blob/master/lib/sqlalchemy/sql/schema.py#L1210

I tested this by `print()`ing the value of `.nullable` for all my properties in `is_column_nullable()`. All were set, and always `True` or `False`.

However, `column_property()` properties do not have a `nullable` attribute set. It's incorrect to assume these properties are not nullable. Here is an example, which returns null and throws in graphene when `func.count(PersonInfo.id)` is 0:

```
Reachout.replied_percent = column_property(
    select([
        func.sum(func.cast(PersonInfo.has_replied, Integer)) /\
            func.cast(func.count(PersonInfo.id), Float)
    ]).where(
        PersonInfo.reachout_id == Reachout.id,
    ),
)
```