### PR TITLE
Make tests run with Python 2 as well

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
     python setup.py develop
   elif [ "$TEST_TYPE" = lint ]; then
     pip install flake8
+    pip install -e .
   fi
 script:
 - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,11 @@ install:
 - |
   if [ "$TEST_TYPE" = build ]; then
     pip install pytest==3.0.2 pytest-cov pytest-benchmark coveralls six mock sqlalchemy_utils
-    pip install -e .
-    python setup.py develop
   elif [ "$TEST_TYPE" = lint ]; then
     pip install flake8
-    pip install -e .
   fi
+  pip install -e .
+  python setup.py develop
 script:
 - |
   if [ "$TEST_TYPE" = lint ]; then

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -43,7 +43,7 @@ class Article(Base):
     reporter_id = Column(Integer(), ForeignKey('reporters.id'))
 
 
-class ReflectedEditor:
+class ReflectedEditor(object):
     """Same as Editor, but using reflected table."""
 
 editor_table = Table('editors', Base.metadata, autoload=True)


### PR DESCRIPTION
SQLAlchemy expects new-style classes.

So the manually mapped class must inherit from object, even though this is not necessary in Python 3.