### PR TITLE
Fix assert message in Register class. Fixes #91.

### DIFF
--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -8,7 +8,7 @@ class Registry(object):
     def register(self, cls):
         from .types import SQLAlchemyObjectType
         assert issubclass(cls, SQLAlchemyObjectType), (
-            'Only classes of type SQLAlchemyObjectType can be registered, ',
+            'Only classes of type SQLAlchemyObjectType can be registered, '
             'received "{}"'
         ).format(cls.__name__)
         assert cls._meta.registry == self, 'Registry for a Model have to match.'

--- a/graphene_sqlalchemy/tests/test_registry.py
+++ b/graphene_sqlalchemy/tests/test_registry.py
@@ -1,0 +1,31 @@
+import pytest
+
+from .models import Pet
+from ..registry import Registry
+from ..types import SQLAlchemyObjectType
+
+
+def test_register_incorrect_objecttype():
+    reg = Registry()
+
+    class Spam:
+        pass
+
+    with pytest.raises(AssertionError) as excinfo:
+        reg.register(Spam)
+
+    assert 'Only classes of type SQLAlchemyObjectType can be registered' in str(excinfo.value)
+
+
+def test_register_objecttype():
+    reg = Registry()
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            registry = reg
+
+    try:
+        reg.register(PetType)
+    except AssertionError:
+        pytest.fail("expected no AssertionError")


### PR DESCRIPTION
Previously, when trying to register an ObjectType which is not supported by Registry-class, an AttributeError is raised instead of AssertError.

We correct the problem by making sure we do not call `format()` on a tuple.

Tests were added for the Registry.register() method.