### PR TITLE
Allow creation of custom connections. Fixes #65.

### DIFF
--- a/graphene_sqlalchemy/tests/conftest.py
+++ b/graphene_sqlalchemy/tests/conftest.py
@@ -1,0 +1,40 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from .models import Article, Base, Editor, Reporter
+from ..registry import reset_global_registry
+
+db = create_engine('sqlite:///test_sqlalchemy.sqlite3')
+
+
+@pytest.yield_fixture(scope='function')
+def session():
+    reset_global_registry()
+    connection = db.engine.connect()
+    transaction = connection.begin()
+    Base.metadata.create_all(connection)
+
+    # options = dict(bind=connection, binds={})
+    session_factory = sessionmaker(bind=connection)
+    session = scoped_session(session_factory)
+
+    yield session
+
+    # Finalize test here
+    transaction.rollback()
+    connection.close()
+    session.remove()
+
+@pytest.yield_fixture(scope='function')
+def setup_fixtures(session):
+    reporter = Reporter(first_name='ABA', last_name='X')
+    session.add(reporter)
+    reporter2 = Reporter(first_name='ABO', last_name='Y')
+    session.add(reporter2)
+    article = Article(headline='Hi!')
+    article.reporter = reporter
+    session.add(article)
+    editor = Editor(name="John")
+    session.add(editor)
+    session.commit()

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -186,4 +186,4 @@ def test_passing_incorrect_connection_instance():
                 connection = 'spam'
                 registry = registry
 
-    assert str(excinfo.value) == "The connection must be a Connection. Received <class 'str'>"
+    assert "The connection must be a Connection. Received" in str(excinfo.value)

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -131,7 +131,7 @@ def test_custom_connection(session, setup_fixtures):
         def resolve_counter(*args, **kwargs):
             return exp_counter
 
-    class ArticleType(SQLAlchemyObjectType, interfaces=[Node]):
+    class ArticleType(SQLAlchemyObjectType):
         class Meta:
             model = Article
             connection = CustomConnection

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -122,9 +122,7 @@ class SQLAlchemyObjectType(ObjectType):
             elif not connection:
                 # Create connection type automatically using graphene.relay.Connection
                 cnx = Connection.create_type('{}Connection'.format(cls.__name__), node=cls)
-            elif isinstance(connection, Connection):
-                cnx = connection.create_type(connection.__name__, node=cls)
-            elif connection:
+            else:
                 cnx = connection
 
         if cnx is not None:


### PR DESCRIPTION
Previously, it was not possible to create custom connections without
monkey patching graphene.relay.Connection. Custom connections are
useful when all connections need a total count for paging, for example.

We change the SQLAlchemyObjectType.__init_subclass_with_meta method
so that when the connection argument is a class, it is used to create
the new connection type.

A test case has been added to check usage of custom connections. The
`conftest.py` was added to allow pytest using database related fixtures
in other places than `test_query.py`.