### PR TITLE
Added sort support

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,7 +3,7 @@ Schema Examples
 
 
 Search all Models with Union
------------------
+----------------------------
 
 .. code:: python
 
@@ -11,12 +11,22 @@ Search all Models with Union
         class Meta:
             model = BookModel
             interfaces = (relay.Node,)
-    
-    
+
+
+    class BookConnection(relay.Connection):
+        class Meta:
+            node = Book
+
+
     class Author(SQLAlchemyObjectType):
         class Meta:
             model = AuthorModel
             interfaces = (relay.Node,)
+
+
+    class AuthorConnection(relay.Connection):
+        class Meta:
+            node = Author
 
 
     class SearchResult(graphene.Union):
@@ -29,8 +39,8 @@ Search all Models with Union
         search = graphene.List(SearchResult, q=graphene.String())  # List field for search results
         
         # Normal Fields
-        all_books = SQLAlchemyConnectionField(Book)
-        all_authors = SQLAlchemyConnectionField(Author)
+        all_books = SQLAlchemyConnectionField(BookConnection)
+        all_authors = SQLAlchemyConnectionField(AuthorConnection)
 
         def resolve_search(self, info, **args):
             q = args.get("q")  # Search query
@@ -47,13 +57,13 @@ Search all Models with Union
             # Query Authors
             authors = author_query.filter(AuthorModel.name.contains(q)).all()
 
-        return authors + books  # Combine lists
+            return authors + books  # Combine lists
 
     schema = graphene.Schema(query=Query, types=[Book, Author, SearchResult])
     
 Example GraphQL query
 
-.. code:: GraphQL
+.. code::
 
     book(id: "Qm9vazow") {
         id

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -2,9 +2,6 @@
 Tips
 ====
 
-Tips
-====
-
 Querying
 --------
 
@@ -30,3 +27,61 @@ For make querying to the database work, there are two alternatives:
 If you don't specify any, the following error will be displayed:
 
 ``A query in the model Base or a session in the schema is required for querying.``
+
+Sorting
+-------
+
+By default the SQLAlchemyConnectionField sorts the result elements over the primary key(s). 
+The query has a `sort` argument which allows to sort over a different column(s)
+
+Given the model
+
+.. code:: python
+
+    class Pet(Base):
+        __tablename__ = 'pets'
+        id = Column(Integer(), primary_key=True)
+        name = Column(String(30))
+        pet_kind = Column(Enum('cat', 'dog', name='pet_kind'), nullable=False)
+
+
+    class PetNode(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+
+    class PetConnection(Connection):
+        class Meta:
+            node = PetNone
+
+
+    class Query(ObjectType):
+        allPets = SQLAlchemyConnectionField(PetConnection)
+
+some of the allowed queries are
+
+-  Sort in ascending order over the `name` column
+
+.. code::
+
+    allPets(sort: name_asc){
+        edges {
+            node {
+                name
+            }
+        }
+    }
+
+-  Sort in descending order over the `per_kind` column and in ascending order over the `name` column
+
+.. code::
+
+    allPets(sort: [pet_kind_desc, name_asc]) {
+        edges {
+            node {
+                name
+                petKind
+            }
+        }
+    }
+

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -102,15 +102,28 @@ Create ``flask_sqlalchemy/schema.py`` and type the following:
             interfaces = (relay.Node, )
 
 
+    class DepartmentConnection(relay.Connection):
+        class Meta:
+            node = Department
+
+
     class Employee(SQLAlchemyObjectType):
         class Meta:
             model = EmployeeModel
             interfaces = (relay.Node, )
 
 
+    class EmployeeConnection(relay.Connection):
+        class Meta:
+            node = Employee
+
+
     class Query(graphene.ObjectType):
         node = relay.Node.Field()
-        all_employees = SQLAlchemyConnectionField(Employee)
+        # Allows sorting over multiple columns, by default over the primary key
+        all_employees = SQLAlchemyConnectionField(EmployeeConnection)
+        # Disable sorting over this field
+        all_departments = SQLAlchemyConnectionField(DepartmentConnection, sort=None)
 
     schema = graphene.Schema(query=Query)
 

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -34,8 +34,8 @@ SortEnumEmployee = utils.sort_enum_for_model(
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
-    all_employees = SQLAlchemyConnectionField(
-        Employee, sort=graphene.Argument(SortEnumEmployee, default_value=['id', 'asc']))
+    all_employees = SQLAlchemyConnectionField(Employee, sort=graphene.Argument(SortEnumEmployee,
+            default_value=utils.EnumValue('id_asc', EmployeeModel.id.asc())))
     all_roles = SQLAlchemyConnectionField(Role, sort=utils.sort_argument_for_model(RoleModel))
     all_departments = SQLAlchemyConnectionField(Department)
 

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -35,7 +35,7 @@ SortEnumEmployee = utils.sort_enum_for_model(
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
     all_employees = SQLAlchemyConnectionField(
-        Employee, sort=graphene.Argument(SortEnumEmployee, default_value=EmployeeModel.id))
+        Employee, sort=graphene.Argument(SortEnumEmployee, default_value=['id', 'asc']))
     all_roles = SQLAlchemyConnectionField(Role, sort=utils.sort_argument_for_model(RoleModel))
     all_departments = SQLAlchemyConnectionField(Department)
 

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -34,10 +34,10 @@ SortEnumEmployee = utils.sort_enum_for_model(
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
-    # Supports sorting only over one field
+    # Allow only single column sorting
     all_employees = SQLAlchemyConnectionField(Employee, sort=graphene.Argument(SortEnumEmployee,
             default_value=utils.EnumValue('id_asc', EmployeeModel.id.asc())))
-    # Add sort over multiple fields, sorting by default over the primary key
+    # Add sort over multiple columns, sorting by default over the primary key
     all_roles = SQLAlchemyConnectionField(Role)
     # Disable sorting over this field
     all_departments = SQLAlchemyConnectionField(Department, sort=None)

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -34,10 +34,13 @@ SortEnumEmployee = utils.sort_enum_for_model(
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
+    # Supports sorting only over one field
     all_employees = SQLAlchemyConnectionField(Employee, sort=graphene.Argument(SortEnumEmployee,
             default_value=utils.EnumValue('id_asc', EmployeeModel.id.asc())))
-    all_roles = SQLAlchemyConnectionField(Role, sort=utils.sort_argument_for_model(RoleModel))
-    all_departments = SQLAlchemyConnectionField(Department)
+    # Add sort over multiple fields, sorting by default over the primary key
+    all_roles = SQLAlchemyConnectionField(Role)
+    # Disable sorting over this field
+    all_departments = SQLAlchemyConnectionField(Department, sort=None)
 
 
 schema = graphene.Schema(query=Query, types=[Department, Employee, Role])

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -7,40 +7,54 @@ from models import Role as RoleModel
 
 
 class Department(SQLAlchemyObjectType):
-
     class Meta:
         model = DepartmentModel
         interfaces = (relay.Node, )
 
 
-class Employee(SQLAlchemyObjectType):
+class DepartmentConnection(relay.Connection):
+    class Meta:
+        node = Department
 
+
+class Employee(SQLAlchemyObjectType):
     class Meta:
         model = EmployeeModel
         interfaces = (relay.Node, )
 
 
-class Role(SQLAlchemyObjectType):
+class EmployeeConnection(relay.Connection):
+    class Meta:
+        node = Employee
 
+
+class Role(SQLAlchemyObjectType):
     class Meta:
         model = RoleModel
         interfaces = (relay.Node, )
 
 
-SortEnumEmployee = utils.sort_enum_for_model(
-    EmployeeModel, 'SortEnumEmployee',
+class RoleConnection(relay.Connection):
+    class Meta:
+        node = Role
+
+
+SortEnumEmployee = utils.sort_enum_for_model(EmployeeModel, 'SortEnumEmployee',
     lambda c, d: c.upper() + ('_ASC' if d else '_DESC'))
 
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
     # Allow only single column sorting
-    all_employees = SQLAlchemyConnectionField(Employee, sort=graphene.Argument(SortEnumEmployee,
+    all_employees = SQLAlchemyConnectionField(
+        EmployeeConnection,
+        sort=graphene.Argument(
+            SortEnumEmployee,
             default_value=utils.EnumValue('id_asc', EmployeeModel.id.asc())))
-    # Add sort over multiple columns, sorting by default over the primary key
-    all_roles = SQLAlchemyConnectionField(Role)
+    # Allows sorting over multiple columns, by default over the primary key
+    all_roles = SQLAlchemyConnectionField(RoleConnection)
     # Disable sorting over this field
-    all_departments = SQLAlchemyConnectionField(Department, sort=None)
+    all_departments = SQLAlchemyConnectionField(DepartmentConnection, sort=None)
 
 
 schema = graphene.Schema(query=Query, types=[Department, Employee, Role])

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -1,6 +1,6 @@
 import graphene
 from graphene import relay
-from graphene_sqlalchemy import SQLAlchemyConnectionField, SQLAlchemyObjectType
+from graphene_sqlalchemy import SQLAlchemyConnectionField, SQLAlchemyObjectType, utils
 from models import Department as DepartmentModel
 from models import Employee as EmployeeModel
 from models import Role as RoleModel
@@ -27,11 +27,17 @@ class Role(SQLAlchemyObjectType):
         interfaces = (relay.Node, )
 
 
+SortEnumEmployee = utils.sort_enum_for_model(
+    EmployeeModel, 'SortEnumEmployee',
+    lambda c, d: c.upper() + ('_ASC' if d else '_DESC'))
+
+
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
-    all_employees = SQLAlchemyConnectionField(Employee)
-    all_roles = SQLAlchemyConnectionField(Role)
-    role = graphene.Field(Role)
+    all_employees = SQLAlchemyConnectionField(
+        Employee, sort=graphene.Argument(SortEnumEmployee, default_value=EmployeeModel.id))
+    all_roles = SQLAlchemyConnectionField(Role, sort=utils.sort_argument_for_model(RoleModel))
+    all_departments = SQLAlchemyConnectionField(Department)
 
 
 schema = graphene.Schema(query=Query, types=[Department, Employee, Role])

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -9,7 +9,7 @@ from graphql_relay.connection.arrayconnection import connection_from_list_slice
 from .utils import get_query, sort_argument_for_model
 
 
-class _UnsortedSQLAlchemyConnectionField(ConnectionField):
+class UnsortedSQLAlchemyConnectionField(ConnectionField):
 
     @property
     def model(self):
@@ -20,9 +20,9 @@ class _UnsortedSQLAlchemyConnectionField(ConnectionField):
         query = get_query(model, info.context)
         if sort is not None:
             if isinstance(sort, str):
-                query = query.order_by(sort.order)
+                query = query.order_by(sort.value)
             else:
-                query = query.order_by(*(value.order for value in sort))
+                query = query.order_by(*(col.value for col in sort))
         return query
 
     @property
@@ -62,7 +62,7 @@ class _UnsortedSQLAlchemyConnectionField(ConnectionField):
         return partial(self.connection_resolver, parent_resolver, self.type, self.model)
 
 
-class SQLAlchemyConnectionField(_UnsortedSQLAlchemyConnectionField):
+class SQLAlchemyConnectionField(UnsortedSQLAlchemyConnectionField):
 
     def __init__(self, type, *args, **kwargs):
         if 'sort' not in kwargs:
@@ -72,7 +72,7 @@ class SQLAlchemyConnectionField(_UnsortedSQLAlchemyConnectionField):
         super(SQLAlchemyConnectionField, self).__init__(type, *args, **kwargs)
 
 
-__connectionFactory = _UnsortedSQLAlchemyConnectionField
+__connectionFactory = UnsortedSQLAlchemyConnectionField
 
 
 def createConnectionField(_type):
@@ -86,4 +86,4 @@ def registerConnectionFieldFactory(factoryMethod):
 
 def unregisterConnectionFieldFactory():
     global __connectionFactory
-    __connectionFactory = _UnsortedSQLAlchemyConnectionField
+    __connectionFactory = UnsortedSQLAlchemyConnectionField

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -19,13 +19,10 @@ class SQLAlchemyConnectionField(ConnectionField):
     def get_query(cls, model, info, sort=None, **args):
         query = get_query(model, info.context)
         if sort is not None:
-            if isinstance(sort[0], str):
-                sort = [sort]
-            order = []
-            for column_name, direction in sort:
-                column = getattr(model, column_name)
-                order.append(getattr(column, direction)())
-            query = query.order_by(*order)
+            if isinstance(sort, str):
+                query = query.order_by(sort.order)
+            else:
+                query = query.order_by(*(value.order for value in sort))
         return query
 
     @property

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -1,4 +1,3 @@
-from collections import Iterable
 from functools import partial
 
 from sqlalchemy.orm.query import Query
@@ -20,7 +19,13 @@ class SQLAlchemyConnectionField(ConnectionField):
     def get_query(cls, model, info, sort=None, **args):
         query = get_query(model, info.context)
         if sort is not None:
-            query = query.order_by(*sort) if isinstance(sort, Iterable) else query.order_by(sort)
+            if isinstance(sort[0], str):
+                sort = [sort]
+            order = []
+            for column_name, direction in sort:
+                column = getattr(model, column_name)
+                order.append(getattr(column, direction)())
+            query = query.order_by(*order)
         return query
 
     @property

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -1,3 +1,4 @@
+from collections import Iterable
 from functools import partial
 
 from sqlalchemy.orm.query import Query
@@ -16,8 +17,11 @@ class SQLAlchemyConnectionField(ConnectionField):
         return self.type._meta.node._meta.model
 
     @classmethod
-    def get_query(cls, model, info, **args):
-        return get_query(model, info.context)
+    def get_query(cls, model, info, sort=None, **args):
+        query = get_query(model, info.context)
+        if sort is not None:
+            query = query.order_by(*sort) if isinstance(sort, Iterable) else query.order_by(sort)
+        return query
 
     @property
     def type(self):

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -69,7 +69,7 @@ class SQLAlchemyConnectionField(UnsortedSQLAlchemyConnectionField):
             try:
                 model = type.Edge.node._type._meta.model
                 kwargs.setdefault('sort', sort_argument_for_model(model))
-            except Exception as e:
+            except Exception:
                 raise Exception(
                     'Cannot create sort argument for {}. A model is required. Set the "sort" argument'
                     ' to None to disabling the creation of the sort query argument'.format(type.__name__)

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -16,7 +16,7 @@ from graphene.types.json import JSONString
 from ..converter import (convert_sqlalchemy_column,
                          convert_sqlalchemy_composite,
                          convert_sqlalchemy_relationship)
-from ..fields import _UnsortedSQLAlchemyConnectionField
+from ..fields import UnsortedSQLAlchemyConnectionField
 from ..registry import Registry
 from ..types import SQLAlchemyObjectType
 from .models import Article, Pet, Reporter
@@ -205,7 +205,7 @@ def test_should_manytomany_convert_connectionorlist_connection():
 
     dynamic_field = convert_sqlalchemy_relationship(Reporter.pets.property, A._meta.registry)
     assert isinstance(dynamic_field, graphene.Dynamic)
-    assert isinstance(dynamic_field.get_type(), _UnsortedSQLAlchemyConnectionField)
+    assert isinstance(dynamic_field.get_type(), UnsortedSQLAlchemyConnectionField)
 
 
 def test_should_manytoone_convert_connectionorlist():

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -16,7 +16,7 @@ from graphene.types.json import JSONString
 from ..converter import (convert_sqlalchemy_column,
                          convert_sqlalchemy_composite,
                          convert_sqlalchemy_relationship)
-from ..fields import SQLAlchemyConnectionField
+from ..fields import _UnsortedSQLAlchemyConnectionField
 from ..registry import Registry
 from ..types import SQLAlchemyObjectType
 from .models import Article, Pet, Reporter
@@ -205,7 +205,7 @@ def test_should_manytomany_convert_connectionorlist_connection():
 
     dynamic_field = convert_sqlalchemy_relationship(Reporter.pets.property, A._meta.registry)
     assert isinstance(dynamic_field, graphene.Dynamic)
-    assert isinstance(dynamic_field.get_type(), SQLAlchemyConnectionField)
+    assert isinstance(dynamic_field.get_type(), _UnsortedSQLAlchemyConnectionField)
 
 
 def test_should_manytoone_convert_connectionorlist():

--- a/graphene_sqlalchemy/tests/test_fields.py
+++ b/graphene_sqlalchemy/tests/test_fields.py
@@ -1,3 +1,6 @@
+from graphene.relay import Connection
+import pytest
+
 from ..fields import SQLAlchemyConnectionField
 from ..types import SQLAlchemyObjectType
 from ..utils import sort_argument_for_model
@@ -9,17 +12,27 @@ class Pet(SQLAlchemyObjectType):
         model = PetModel
 
 
+class PetConn(Connection):
+    class Meta:
+        node = Pet
+
+
 def test_sort_added_by_default():
-    arg = SQLAlchemyConnectionField(Pet)
+    arg = SQLAlchemyConnectionField(PetConn)
     assert 'sort' in arg.args
     assert arg.args['sort'] == sort_argument_for_model(PetModel)
 
 
 def test_sort_can_be_removed():
-    arg = SQLAlchemyConnectionField(Pet, sort=None)
+    arg = SQLAlchemyConnectionField(PetConn, sort=None)
     assert 'sort' not in arg.args
 
 
 def test_custom_sort():
-    arg = SQLAlchemyConnectionField(Pet, sort=sort_argument_for_model(Editor))
+    arg = SQLAlchemyConnectionField(PetConn, sort=sort_argument_for_model(Editor))
     assert arg.args['sort'] == sort_argument_for_model(Editor)
+
+
+def test_init_raises():
+    with pytest.raises(Exception, match='Cannot create sort'):
+        SQLAlchemyConnectionField(Connection)

--- a/graphene_sqlalchemy/tests/test_fields.py
+++ b/graphene_sqlalchemy/tests/test_fields.py
@@ -1,0 +1,25 @@
+from ..fields import SQLAlchemyConnectionField
+from ..types import SQLAlchemyObjectType
+from ..utils import sort_argument_for_model
+from .models import Pet as PetModel, Editor
+
+
+class Pet(SQLAlchemyObjectType):
+    class Meta:
+        model = PetModel
+
+
+def test_sort_added_by_default():
+    arg = SQLAlchemyConnectionField(Pet)
+    assert 'sort' in arg.args
+    assert arg.args['sort'] == sort_argument_for_model(PetModel)
+
+
+def test_sort_can_be_removed():
+    arg = SQLAlchemyConnectionField(Pet, sort=None)
+    assert 'sort' not in arg.args
+
+
+def test_custom_sort():
+    arg = SQLAlchemyConnectionField(Pet, sort=sort_argument_for_model(Editor))
+    assert arg.args['sort'] == sort_argument_for_model(Editor)

--- a/graphene_sqlalchemy/tests/test_query.py
+++ b/graphene_sqlalchemy/tests/test_query.py
@@ -3,7 +3,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 import graphene
-from graphene.relay import Node
+from graphene.relay import Connection, Node
 
 from ..registry import reset_global_registry
 from ..fields import SQLAlchemyConnectionField
@@ -153,7 +153,7 @@ def test_should_node(session):
         # def get_node(cls, id, info):
         #     return Article(id=1, headline='Article node')
 
-    class ArticleConnection(graphene.relay.Connection):
+    class ArticleConnection(Connection):
         class Meta:
             node = ArticleNode
 
@@ -243,7 +243,7 @@ def test_should_custom_identifier(session):
             model = Editor
             interfaces = (Node, )
 
-    class EditorConnection(graphene.relay.Connection):
+    class EditorConnection(Connection):
         class Meta:
             node = EditorNode
 
@@ -394,16 +394,20 @@ def test_sort(session):
             model = Pet
             interfaces = (Node, )
 
+    class PetConnection(Connection):
+        class Meta:
+            node = PetNode
+
     class Query(graphene.ObjectType):
-        defaultSort = SQLAlchemyConnectionField(PetNode)
-        nameSort = SQLAlchemyConnectionField(PetNode)
-        multipleSort = SQLAlchemyConnectionField(PetNode)
-        descSort = SQLAlchemyConnectionField(PetNode)
+        defaultSort = SQLAlchemyConnectionField(PetConnection)
+        nameSort = SQLAlchemyConnectionField(PetConnection)
+        multipleSort = SQLAlchemyConnectionField(PetConnection)
+        descSort = SQLAlchemyConnectionField(PetConnection)
         singleColumnSort = SQLAlchemyConnectionField(
-            PetNode, sort=graphene.Argument(sort_enum_for_model(Pet)))
+            PetConnection, sort=graphene.Argument(sort_enum_for_model(Pet)))
         noDefaultSort = SQLAlchemyConnectionField(
-            PetNode, sort=sort_argument_for_model(Pet, False))
-        noSort = SQLAlchemyConnectionField(PetNode, sort=None)
+            PetConnection, sort=sort_argument_for_model(Pet, False))
+        noSort = SQLAlchemyConnectionField(PetConnection, sort=None)
 
     query = '''
         query sortTest {

--- a/graphene_sqlalchemy/tests/test_utils.py
+++ b/graphene_sqlalchemy/tests/test_utils.py
@@ -1,6 +1,8 @@
-from graphene import ObjectType, Schema, String
+from graphene import Enum, List, ObjectType, Schema, String
+import sqlalchemy as sa
 
-from ..utils import get_session
+from ..utils import get_session, sort_enum_for_model, sort_argument_for_model
+from .models import Pet, Editor
 
 
 def test_get_session():
@@ -22,3 +24,52 @@ def test_get_session():
     result = schema.execute(query, context_value={'session': session})
     assert not result.errors
     assert result.data['x'] == session
+
+
+def test_sort_enum_for_model():
+    enum = sort_enum_for_model(Pet)
+    assert isinstance(enum, type(Enum))
+    assert str(enum) == 'PetSortEnum'
+    for col in sa.inspect(Pet).columns:
+        assert hasattr(enum, col.name + '_asc')
+        assert hasattr(enum, col.name + '_desc')
+
+
+def test_sort_enum_for_model_custom_naming():
+    enum = sort_enum_for_model(Pet, 'Foo',
+                               lambda n, d: n.upper() + ('A' if d else 'D'))
+    assert str(enum) == 'Foo'
+    for col in sa.inspect(Pet).columns:
+        assert hasattr(enum, col.name.upper() + 'A')
+        assert hasattr(enum, col.name.upper() + 'D')
+
+
+def test_enum_cache():
+    assert sort_enum_for_model(Editor) is sort_enum_for_model(Editor)
+
+
+def test_sort_argument_for_model():
+    arg = sort_argument_for_model(Pet)
+
+    assert isinstance(arg.type, List)
+    assert arg.default_value == [Pet.id.name + '_asc']
+    assert arg.type.of_type == sort_enum_for_model(Pet)
+
+
+def test_sort_argument_for_model_no_default():
+    arg = sort_argument_for_model(Pet, False)
+
+    assert arg.default_value is None
+
+
+def test_sort_argument_for_model_multiple_pk():
+    Base = sa.ext.declarative.declarative_base()
+
+    class MultiplePK(Base):
+        foo = sa.Column(sa.Integer, primary_key=True)
+        bar = sa.Column(sa.Integer, primary_key=True)
+        __tablename__ = 'MultiplePK'
+
+    arg = sort_argument_for_model(MultiplePK)
+    assert set(arg.default_value) == set((MultiplePK.foo.name + '_asc',
+                                          MultiplePK.bar.name + '_asc'))

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -1,4 +1,6 @@
+from graphene import Argument, Enum, List
 from sqlalchemy.exc import ArgumentError
+from sqlalchemy.inspection import inspect
 from sqlalchemy.orm import class_mapper, object_mapper
 from sqlalchemy.orm.exc import UnmappedClassError, UnmappedInstanceError
 
@@ -34,3 +36,51 @@ def is_mapped_instance(cls):
         return False
     else:
         return True
+
+
+def _symbol_name(column_name, is_asc):
+    return column_name + ('_asc' if is_asc else '_desc')
+
+
+def _sort_enum_for_model(cls, name=None, symbol_name=_symbol_name):
+    name = name or cls.__name__ + 'SortEnum'
+    items = []
+    default = []
+    for column in inspect(cls).columns.values():
+        asc = symbol_name(column.name, True), column.asc()
+        desc = symbol_name(column.name, False), column.desc()
+        if column.primary_key:
+            default.append(asc[1])
+        items.extend((asc, desc))
+    return Enum(name, items), default
+
+
+def sort_enum_for_model(cls, name=None, symbol_name=_symbol_name):
+    '''Create Graphene Enum for sorting a SQLAlchemy class query
+
+    Parameters
+    - cls : Sqlalchemy model class
+        Model used to create the sort enumerator
+    - name : str, optional, default None
+        Name to use for the enumerator. If not provided it will be set to `cls.__name__ + 'SortEnum'`
+    - symbol_name : function, optional, default `_symbol_name`
+        Function which takes the column name and a boolean indicating if the sort direction is ascending,
+        and returns the symbol name for the current column and sort direction.
+        The default function will create, for a column named 'foo', the symbols 'foo_asc' and 'foo_desc'
+
+    Returns
+    - Enum
+        The Graphene enumerator
+    '''
+    enum, _ = _sort_enum_for_model(cls, name, symbol_name)
+    return enum
+
+
+def sort_argument_for_model(cls, has_default=True):
+    '''Returns an Graphene argument for the sort field that accepts a list of sorting directions for a model.
+    If `has_default` is True (the default) it will sort the result by the primary key(s)
+    '''
+    enum, default = _sort_enum_for_model(cls)
+    if not has_default:
+        default = None
+    return Argument(List(enum), default_value=default)

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -42,16 +42,28 @@ def _symbol_name(column_name, is_asc):
     return column_name + ('_asc' if is_asc else '_desc')
 
 
+class EnumValue(str):
+    '''Subclass of str that stores a string value and the sort order of the column'''
+    def __new__(cls, str_value, order):
+        return super(EnumValue, cls).__new__(cls, str_value)
+
+    def __init__(self, str_value, order):
+        super(EnumValue, self).__init__()
+        self.order = order
+
+
 def _sort_enum_for_model(cls, name=None, symbol_name=_symbol_name):
     name = name or cls.__name__ + 'SortEnum'
     items = []
     default = []
     for column in inspect(cls).columns.values():
-        asc = symbol_name(column.name, True), [column.name, 'asc']
-        desc = symbol_name(column.name, False), [column.name, 'desc']
+        asc_name = symbol_name(column.name, True)
+        asc_value = EnumValue(asc_name, column.asc())
+        desc_name = symbol_name(column.name, False)
+        desc_value = EnumValue(desc_name, column.desc())
         if column.primary_key:
-            default.append(asc[1])
-        items.extend((asc, desc))
+            default.append(asc_value)
+        items.extend(((asc_name, asc_value), (desc_name, desc_value)))
     return Enum(name, items), default
 
 

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -47,8 +47,8 @@ def _sort_enum_for_model(cls, name=None, symbol_name=_symbol_name):
     items = []
     default = []
     for column in inspect(cls).columns.values():
-        asc = symbol_name(column.name, True), column.asc()
-        desc = symbol_name(column.name, False), column.desc()
+        asc = symbol_name(column.name, True), [column.name, 'asc']
+        desc = symbol_name(column.name, False), [column.name, 'desc']
         if column.primary_key:
             default.append(asc[1])
         items.extend((asc, desc))


### PR DESCRIPTION
Add support for sorting the return values of a `SQLAlchemyConnectionField`

The `sort` argument of `SQLAlchemyConnectionField` supports sorting over a single over multiple field.

In the utils file I've added
-  the function `sort_enum_for_model` to create a graphene Enum with all be possible field and order combination for a particular sqlalchemy model as suggested by @Cito 
- the function `sort_argument_for_model` to automacally create the enum and return the attribute to use in the connection field

The test and documentation are still missing, because first I wanted to get some feedback about the implementation.

Regarding the value of the sort enumerator at first I tried to set the values of the enum to the ascenting or descenting operators of sqlalchemy simplify the logic of the get_query but that results in an error when graphql builds the ast graph, so I reverted to use a list column_name, operator that is less than optimal since every time it needs to query the model to create the operators.


Thanks to @Cito to the input in #40 
Closes #40