### PR TITLE
Added support for total count on relay connections

### DIFF
--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -25,6 +25,8 @@ class Role(SQLAlchemyObjectType):
     class Meta:
         model = RoleModel
         interfaces = (relay.Node, )
+        # Disable the total count on this connection
+        total_count = False
 
 
 class Query(graphene.ObjectType):

--- a/graphene_sqlalchemy/tests/test_query.py
+++ b/graphene_sqlalchemy/tests/test_query.py
@@ -365,3 +365,33 @@ def test_should_mutate_well(session):
     result = schema.execute(query, context_value={'session': session})
     assert not result.errors
     assert result.data == expected
+
+
+def test_should_return_total_count(session):
+    setup_fixtures(session)
+
+    class ReporterNode(SQLAlchemyObjectType):
+
+        class Meta:
+            model = Reporter
+            interfaces = (Node, )
+
+    class Query(graphene.ObjectType):
+        all_article = SQLAlchemyConnectionField(ReporterNode)
+
+    query = '''
+        {
+          allArticle {
+            totalCount
+          }
+        }
+    '''
+    expected = {
+        'allArticle': {
+            'totalCount': session.query(Reporter).count()
+        },
+    }
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query, context_value={'session': session})
+    assert not result.errors
+    assert result.data == expected

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -1,10 +1,10 @@
 
 from graphene import Field, Int, Interface, ObjectType
-from graphene.relay import Node, is_node
+from graphene.relay import Node, is_node, Connection
 import six
 
 from ..registry import Registry
-from ..types import SQLAlchemyObjectType
+from ..types import SQLAlchemyObjectType, ConnectionWithCount
 from .models import Article, Reporter
 
 registry = Registry()
@@ -116,3 +116,22 @@ def test_custom_objecttype_registered():
         'pets',
         'articles',
         'favorite_article']
+
+def test_total_count():
+    class TotalCount(SQLAlchemyObjectType):
+        class Meta:
+            model = Article
+            interfaces = (Node, )
+            registry = registry
+
+    class NoTotalCount(SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node, )
+            registry = registry
+            total_count = False
+
+    assert issubclass(TotalCount._meta.connection, ConnectionWithCount)
+    assert not issubclass(NoTotalCount._meta.connection, ConnectionWithCount)
+    assert issubclass(TotalCount._meta.connection, Connection)
+    assert issubclass(NoTotalCount._meta.connection, Connection)


### PR DESCRIPTION
This PR adds support for returning the length of a `ConnectionField` under the argument `totalCount`
Example query:  
`{ allArticles { totalCount } }`  
will return  
`{ "allArticles": { "totalCount": <number of articles>        } } `

This option is added by default, but can be disabled by adding `total_count = False` to the `Meta` of a node line in the example below:
```py
class Role(SQLAlchemyObjectType):
    class Meta:
        model = RoleModel
        interfaces = (relay.Node, )
        # Disable the total count on this connection
        total_count = False
```

I've added the tests for this, but I do not know where should I add the documentation. What's your advice @syrusakbary
Closes #58
