### PR TITLE
Update converter.py again to include INET and CIDR types.

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -92,6 +92,8 @@ def convert_sqlalchemy_type(type, column, registry=None):
 @convert_sqlalchemy_type.register(types.Unicode)
 @convert_sqlalchemy_type.register(types.UnicodeText)
 @convert_sqlalchemy_type.register(postgresql.UUID)
+@convert_sqlalchemy_type.register(postgresql.INET)
+@convert_sqlalchemy_type.register(postgresql.CIDR)
 @convert_sqlalchemy_type.register(TSVectorType)
 def convert_column_to_string(type, column, registry=None):
     return String(description=get_column_doc(column),


### PR DESCRIPTION
Type coverage for this is poor and needs to address a wider array of types provided by SQLAlchemy.