### PR TITLE
Fixed a typo.

### DIFF
--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -52,7 +52,7 @@ Given the model
 
     class PetConnection(Connection):
         class Meta:
-            node = PetNone
+            node = PetNode
 
 
     class Query(ObjectType):


### PR DESCRIPTION
There was a typo in the node name -- `PetNone` instead of `PetNode`.