### PR TITLE
MySQL Enum conversion issue

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -150,8 +150,11 @@ def convert_enum_to_enum(type, column, registry=None):
         items = type.enum_class.__members__.items()
     except AttributeError:
         items = zip(type.enums, type.enums)
+
+    enum_name = type.name or "{}_{}".format(column.table, column.name)
+
     return Field(
-        Enum(type.name, items),
+        Enum(enum_name, items),
         description=get_column_doc(column),
         required=not (is_column_nullable(column)),
     )


### PR DESCRIPTION
When using reflection to build the models (instead of declarative) the Enum conversion fails because the ENUM column is treated as string so doing type.name returns None.

```sql
CREATE TABLE `foos` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `status` ENUM('open', 'closed') DEFAULT 'open',
  PRIMARY KEY (`id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8;
```

```python
class Foo(Base):

    __table__ = Table('foos', metadata, autoload=True)

```

For some reason these kind of enums are returned as Strings so in the type definition we have to specify the field as string

```python
class FooType(SQLAlchemyObjectType):
    class Meta:
        model = Foo
        interfaces = (relay.Node, )
  
    status = String()
```