### PR TITLE
Add filters

### DIFF
--- a/graphene_sqlalchemy/__init__.py
+++ b/graphene_sqlalchemy/__init__.py
@@ -1,5 +1,5 @@
 from .types import SQLAlchemyObjectType
-from .fields import SQLAlchemyConnectionField
+from .fields import SQLAlchemyConnectionField, FilterableConnectionField
 from .utils import get_query, get_session
 
 __version__ = "2.1.0"
@@ -8,6 +8,7 @@ __all__ = [
     "__version__",
     "SQLAlchemyObjectType",
     "SQLAlchemyConnectionField",
+    "FilterableConnectionField",
     "get_query",
     "get_session",
 ]

--- a/graphene_sqlalchemy/filters.py
+++ b/graphene_sqlalchemy/filters.py
@@ -1,0 +1,71 @@
+import graphene
+
+from collections import OrderedDict
+from graphene import Argument, Field
+from sqlalchemy import inspect
+
+# Cache for the generated classes, to avoid name clash
+_INPUT_CACHE = {}
+_INPUT_FIELDS_CACHE = {}
+
+
+class Filter:
+    @staticmethod
+    def add_filter_to_query(query, model, field, value):
+        [(operator, value)] = value.items()
+        if operator == 'eq':
+            query = query.filter(getattr(model, field) == value)
+        elif operator == 'ne':
+            query = query.filter(getattr(model, field) == value)
+        elif operator == 'lt':
+            query = query.filter(getattr(model, field) < value)
+        elif operator == 'gt':
+            query = query.filter(getattr(model, field) > value)
+        elif operator == 'like':
+            query = query.filter(getattr(model, field).like(value))
+        return query
+
+
+def filter_class_for_module(cls):
+    name = cls.__name__ + "InputFilter"
+    if name in _INPUT_CACHE:
+        return Argument(_INPUT_CACHE[name])
+
+    class InputFilterBase:
+        pass
+
+    fields = OrderedDict()
+    for column in inspect(cls).columns.values():
+        maybe_field = create_input_filter_field(column)
+        if maybe_field:
+            fields[column.name] = maybe_field
+    input_class = type(name, (InputFilterBase, graphene.InputObjectType), {})
+    input_class._meta.fields.update(fields)
+    _INPUT_CACHE[name] = input_class
+    return Argument(input_class)
+
+
+def create_input_filter_field(column):
+    from .converter import convert_sqlalchemy_type
+    graphene_type = convert_sqlalchemy_type(column.type, column)
+    if graphene_type.__class__ == Field:  # TODO enum not supported
+        return None
+    name = str(graphene_type.__class__) + 'Filter'
+
+    if name in _INPUT_FIELDS_CACHE:
+        return Field(_INPUT_FIELDS_CACHE[name])
+
+    field_class = Filter
+    fields = OrderedDict()
+    fields['eq'] = Field(graphene_type.__class__, description='Field should be equal to given value')
+    fields['ne'] = Field(graphene_type.__class__, description='Field should not be equal to given value')
+    fields['lt'] = Field(graphene_type.__class__, description='Field should be less then given value')
+    fields['gt'] = Field(graphene_type.__class__, description='Field should be great then given value')
+    fields['like'] = Field(graphene_type.__class__, description='Field should have a pattern of given value')
+    # TODO construct operators based on __class__
+    # TODO complex filter support: OR
+
+    field_class = type(name, (field_class, graphene.InputObjectType), {})
+    field_class._meta.fields.update(fields)
+    _INPUT_FIELDS_CACHE[name] = field_class
+    return Field(field_class)


### PR DESCRIPTION
Add filters support for connections.
```
    class Query(graphene.ObjectType):
        pets = FilterableConnectionField(PetConnection)
```
FilterableConnectionField will create InputFilter object with filters for every Connection's Node's property. The date type will be the same as in Node object. Currenly enums and comlex objects (not scalars) are not supported.

I've added this filter operations: `eq`, `ne`, `like`, `lt`, `gt` based on `sqlalchemy.sql.operators`.

Query:
```
query {
        pets(filter: {name: {eq: "Lassie"}}) {
            edges {
                node {
                    name
                }
            }
        }
    }
```
Multiple filters will always work like AND.
This wil generate `select * from pets where name == "Lassie"`

