### PR TITLE
Fix for enum type duplication in graphene schema

### DIFF
--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -3,6 +3,7 @@ class Registry(object):
         self._registry = {}
         self._registry_models = {}
         self._registry_composites = {}
+        self._registry_enums = {}
 
     def register(self, cls):
         from .types import SQLAlchemyObjectType
@@ -26,6 +27,12 @@ class Registry(object):
 
     def get_converter_for_composite(self, composite):
         return self._registry_composites.get(composite)
+
+    def register_type_for_enum(self, enum_type_name, graphene_enum):
+        self._registry_enums[enum_type_name] = graphene_enum
+
+    def get_type_for_enum(self, enum_type_name):
+        return self._registry_enums.get(enum_type_name)
 
 
 registry = None

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -21,12 +21,14 @@ class Editor(Base):
     editor_id = Column(Integer(), primary_key=True)
     name = Column(String(100))
 
+PetKindEnum = Enum("cat", "dog", name="pet_kind")
 
 class Pet(Base):
     __tablename__ = "pets"
     id = Column(Integer(), primary_key=True)
     name = Column(String(30))
-    pet_kind = Column(Enum("cat", "dog", name="pet_kind"), nullable=False)
+    pet_kind = Column(PetKindEnum, nullable=False)
+    pet_kind_again = Column(PetKindEnum)
     reporter_id = Column(Integer(), ForeignKey("reporters.id"))
 
 


### PR DESCRIPTION
The converter code was created a new type for each Enum column that it
encountered. The problem is where the same Enum type is used for
multiple columns. In that case graphene will notice two schema types
with the same underlying name and throw an Assertion error like:

AssertionError: Found different types with the same name in the schema: pet_kind, pet_kind.

This fix creates a new registry dict for storing a type.name to Enum
mapping that allows for reuse.