### PR TITLE
Don't suppress SQLAlchemy errors when mapping classes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 default_language_version:
     python: python3.7
 repos:
--   repo: git://github.com/pre-commit/pre-commit-hooks
+-   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: c8bad492e1b1d65d9126dba3fe3bd49a5a52b9d6  # v2.1.0
     hooks:
     -   id: check-merge-conflict
@@ -11,15 +11,15 @@ repos:
         exclude: ^docs/.*$
     -   id: trailing-whitespace
         exclude: README.md
--   repo: git://github.com/PyCQA/flake8
+-   repo: https://github.com/PyCQA/flake8
     rev: 88caf5ac484f5c09aedc02167c59c66ff0af0068  # 3.7.7
     hooks:
     -   id: flake8
--   repo: git://github.com/asottile/seed-isort-config
+-   repo: https://github.com/asottile/seed-isort-config
     rev: v1.7.0
     hooks:
     -   id: seed-isort-config
--   repo: git://github.com/pre-commit/mirrors-isort
+-   repo: https://github.com/pre-commit/mirrors-isort
     rev: v4.3.4
     hooks:
     -   id: isort

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -207,9 +207,11 @@ class SQLAlchemyObjectType(ObjectType):
         _meta=None,
         **options
     ):
-        assert is_mapped_class(model), (
-            "You need to pass a valid SQLAlchemy Model in " '{}.Meta, received "{}".'
-        ).format(cls.__name__, model)
+        # Make sure model is a valid SQLAlchemy model
+        if not is_mapped_class(model):
+            raise ValueError(
+                "You need to pass a valid SQLAlchemy Model in " '{}.Meta, received "{}".'.format(cls.__name__, model)
+            )
 
         if not registry:
             registry = get_global_registry()

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -27,7 +27,13 @@ def get_query(model, context):
 def is_mapped_class(cls):
     try:
         class_mapper(cls)
-    except (ArgumentError, UnmappedClassError):
+    except ArgumentError as error:
+        # Only handle ArgumentErrors for non-class objects
+        if "Class object expected" in str(error):
+            return False
+        raise
+    except UnmappedClassError:
+        # Unmapped classes return false
         return False
     else:
         return True


### PR DESCRIPTION
Currently, many SQLAlchemy model definition errors are hidden the way we check if valid models have been provided. This PR allows SQLAlchemy model definition errors to propagate at model check time, and adds a test to confirm that errors are correctly propagated.

Fixes #121 