### PR TITLE
Use enum34 backport when Enum is not available

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: python
 matrix:
   include:
     # Python 2.7
-    # TODO Fix enum and add back tests for py27
-    # See https://github.com/graphql-python/graphene-sqlalchemy/pull/177
-    # - env: TOXENV=py27
-    #   python: 2.7
+    - env: TOXENV=py27
+      python: 2.7
     # Python 3.5
     - env: TOXENV=py34
       python: 3.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,6 @@
+[aliases]
+test=pytest
+
 [flake8]
 exclude = setup.py,docs/*,examples/*,tests
 max-line-length = 120

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,19 @@ with open("graphene_sqlalchemy/__init__.py", "rb") as f:
         ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
     )
 
+requirements = [
+    # To keep things simple, we only support newer versions of Graphene
+    "graphene>=2.1.3,<3",
+    # Tests fail with 1.0.19
+    "SQLAlchemy>=1.1,<2",
+    "six>=1.10.0,<2",
+    "singledispatch>=3.4.0.3,<4",
+]
+try:
+    import Enum
+except ImportError:
+    requirements.append("enum34 >= 1.1.6")
+
 tests_require = [
     "pytest==4.3.1",
     "mock==2.0.0",
@@ -42,14 +55,7 @@ setup(
     ],
     keywords="api graphql protocol rest relay graphene",
     packages=find_packages(exclude=["tests"]),
-    install_requires=[
-        # To keep things simple, we only support newer versions of Graphene
-        "graphene>=2.1.3,<3",
-        # Tests fail with 1.0.19
-        "SQLAlchemy>=1.1,<2",
-        "six>=1.10.0,<2",
-        "singledispatch>=3.4.0.3,<4",
-    ],
+    install_requires=requirements,
     extras_require={
         "dev": [
             "tox==3.7.0",  # Should be kept in sync with tox.ini

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ requirements = [
 ]
 try:
     import enum
-except ImportError:
+except ImportError:  # Python < 2.7 and Python 3.3
     requirements.append("enum34 >= 1.1.6")
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ requirements = [
     "singledispatch>=3.4.0.3,<4",
 ]
 try:
-    import Enum
+    import enum
 except ImportError:
     requirements.append("enum34 >= 1.1.6")
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pre-commit,py{34,35,36,37}-sql{11,12,13}
+envlist = pre-commit,py{27,34,35,36,37}-sql{11,12,13}
 skipsdist = true
 minversion = 3.7.0
 


### PR DESCRIPTION
Tests were broken in Python < 3.4, this PR fix its