### PR TITLE
Add a meta option to allow field names renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ class User(SQLAlchemyObjectType):
         only_fields = ("name",)
         # exclude specified fields
         exclude_fields = ("last_name",)
-        # alias specified fields
-        aliased_fields = {'name': 'first_name'}
+        # Rename specified fields
+        rename_fields = {'name': 'first_name'}
 
 class Query(graphene.ObjectType):
     users = graphene.List(User)

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ class User(SQLAlchemyObjectType):
         only_fields = ("name",)
         # exclude specified fields
         exclude_fields = ("last_name",)
+        # alias specified fields
+        aliased_fields = {'name': 'first_name'}
 
 class Query(graphene.ObjectType):
     users = graphene.List(User)

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -58,6 +58,7 @@ class Article(Base):
     __tablename__ = "articles"
     id = Column(Integer(), primary_key=True)
     headline = Column(String(100))
+    description = Column(String(100))
     pub_date = Column(Date())
     reporter_id = Column(Integer(), ForeignKey("reporters.id"))
 

--- a/graphene_sqlalchemy/tests/test_reflected.py
+++ b/graphene_sqlalchemy/tests/test_reflected.py
@@ -19,3 +19,15 @@ def test_objecttype_registered():
     assert Reflected._meta.model == ReflectedEditor
     assert list(Reflected._meta.fields) == ["editor_id", "name"]
 
+
+class ReflectedWithFieldRenamed(SQLAlchemyObjectType):
+    class Meta:
+        model = ReflectedEditor
+        registry = registry
+        rename_fields = {
+            "name": "editor_name",
+        }
+
+
+def test_objecttype_registered_with_rename_fields():
+    assert list(ReflectedWithFieldRenamed._meta.fields) == ["editor_id", "editor_name"]

--- a/graphene_sqlalchemy/tests/test_reflected.py
+++ b/graphene_sqlalchemy/tests/test_reflected.py
@@ -17,5 +17,5 @@ class Reflected(SQLAlchemyObjectType):
 def test_objecttype_registered():
     assert issubclass(Reflected, ObjectType)
     assert Reflected._meta.model == ReflectedEditor
-    assert list(Reflected._meta.fields.keys()) == ["editor_id", "name"]
+    assert list(Reflected._meta.fields) == ["editor_id", "name"]
 

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -183,7 +183,7 @@ def test_promise_connection_resolver():
     assert result is not None
 
 
-class HumanWithFieldAliased(SQLAlchemyObjectType):
+class HumanWithFieldRenamed(SQLAlchemyObjectType):
 
     publication_timestamp = Int()
 
@@ -191,7 +191,7 @@ class HumanWithFieldAliased(SQLAlchemyObjectType):
         model = Article
         registry = registry
         interfaces = (Node,)
-        aliased_fields = {
+        rename_fields = {
             "id": "article_id",
             "headline": "title",
             "pub_date": "publication_timestamp",
@@ -200,17 +200,18 @@ class HumanWithFieldAliased(SQLAlchemyObjectType):
         }
 
 
-def test_objecttype_with_aliased_fields():
-    assert issubclass(HumanWithFieldAliased, ObjectType)
-    assert HumanWithFieldAliased._meta.model == Article
-    assert list(HumanWithFieldAliased._meta.fields.keys()) == [
+def test_objecttype_with_rename_fields():
+    assert issubclass(HumanWithFieldRenamed, ObjectType)
+    assert HumanWithFieldRenamed._meta.model == Article
+    assert list(HumanWithFieldRenamed._meta.fields) == [
         "article_id",
         "title",
+        "description",
         "publication_timestamp",
         "journalist_id",
         "journalist",
         "id",  # Graphene Node ID
     ]
-    replaced_field = HumanWithFieldAliased._meta.fields["publication_timestamp"]
+    replaced_field = HumanWithFieldRenamed._meta.fields["publication_timestamp"]
     assert isinstance(replaced_field, Field)
     assert replaced_field.type == Int

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -47,7 +47,7 @@ def test_sqlalchemy_interface():
 def test_objecttype_registered():
     assert issubclass(Character, ObjectType)
     assert Character._meta.model == Reporter
-    assert list(Character._meta.fields.keys()) == [
+    assert list(Character._meta.fields) == [
         "id",
         "first_name",
         "last_name",
@@ -87,7 +87,7 @@ def test_object_type():
             interfaces = (Node,)
 
     assert issubclass(Human, ObjectType)
-    assert list(Human._meta.fields.keys()) == [
+    assert list(Human._meta.fields) == [
         "id",
         "headline",
         "pub_date",
@@ -114,7 +114,7 @@ class CustomCharacter(CustomSQLAlchemyObjectType):
 def test_custom_objecttype_registered():
     assert issubclass(CustomCharacter, ObjectType)
     assert CustomCharacter._meta.model == Reporter
-    assert list(CustomCharacter._meta.fields.keys()) == [
+    assert list(CustomCharacter._meta.fields) == [
         "id",
         "first_name",
         "last_name",
@@ -157,7 +157,7 @@ class ReporterWithCustomOptions(SQLAlchemyObjectTypeWithCustomOptions):
 def test_objecttype_with_custom_options():
     assert issubclass(ReporterWithCustomOptions, ObjectType)
     assert ReporterWithCustomOptions._meta.model == Reporter
-    assert list(ReporterWithCustomOptions._meta.fields.keys()) == [
+    assert list(ReporterWithCustomOptions._meta.fields) == [
         "custom_field",
         "id",
         "first_name",

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -90,6 +90,7 @@ def test_object_type():
     assert list(Human._meta.fields) == [
         "id",
         "headline",
+        "description",
         "pub_date",
         "reporter_id",
         "reporter",

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -181,3 +181,36 @@ def test_promise_connection_resolver():
         resolver, TestConnection, ReporterWithCustomOptions, None, None
     )
     assert result is not None
+
+
+class HumanWithFieldAliased(SQLAlchemyObjectType):
+
+    publication_timestamp = Int()
+
+    class Meta:
+        model = Article
+        registry = registry
+        interfaces = (Node,)
+        aliased_fields = {
+            "id": "article_id",
+            "headline": "title",
+            "pub_date": "publication_timestamp",
+            "reporter_id": "journalist_id",
+            "reporter": "journalist",
+        }
+
+
+def test_objecttype_with_aliased_fields():
+    assert issubclass(HumanWithFieldAliased, ObjectType)
+    assert HumanWithFieldAliased._meta.model == Article
+    assert list(HumanWithFieldAliased._meta.fields.keys()) == [
+        "article_id",
+        "title",
+        "publication_timestamp",
+        "journalist_id",
+        "journalist",
+        "id",  # Graphene Node ID
+    ]
+    replaced_field = HumanWithFieldAliased._meta.fields["publication_timestamp"]
+    assert isinstance(replaced_field, Field)
+    assert replaced_field.type == Int


### PR DESCRIPTION
Example is given in the README.md and in tests

It allows to implement : 

```
class User(SQLAlchemyObjectType):
    class Meta:
        model = UserModel
        aliased_fields = {'name': 'first_name'}
```
To be able to have a field named `first_name` in your graphql schema instead of being stucked with UserModel field name `name`