### PR TITLE
Fix #190 - update flask example version

### DIFF
--- a/examples/flask_sqlalchemy/requirements.txt
+++ b/examples/flask_sqlalchemy/requirements.txt
@@ -1,4 +1,4 @@
 graphene[sqlalchemy]
 SQLAlchemy==1.0.11
-Flask==0.10.1
+Flask==0.12.4
 Flask-GraphQL==1.3.0

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -12,31 +12,16 @@ class Department(SQLAlchemyObjectType):
         interfaces = (relay.Node, )
 
 
-class DepartmentConnection(relay.Connection):
-    class Meta:
-        node = Department
-
-
 class Employee(SQLAlchemyObjectType):
     class Meta:
         model = EmployeeModel
         interfaces = (relay.Node, )
 
 
-class EmployeeConnection(relay.Connection):
-    class Meta:
-        node = Employee
-
-
 class Role(SQLAlchemyObjectType):
     class Meta:
         model = RoleModel
         interfaces = (relay.Node, )
-
-
-class RoleConnection(relay.Connection):
-    class Meta:
-        node = Role
 
 
 SortEnumEmployee = utils.sort_enum_for_model(EmployeeModel, 'SortEnumEmployee',
@@ -47,14 +32,14 @@ class Query(graphene.ObjectType):
     node = relay.Node.Field()
     # Allow only single column sorting
     all_employees = SQLAlchemyConnectionField(
-        EmployeeConnection,
+        Employee,
         sort=graphene.Argument(
             SortEnumEmployee,
             default_value=utils.EnumValue('id_asc', EmployeeModel.id.asc())))
     # Allows sorting over multiple columns, by default over the primary key
-    all_roles = SQLAlchemyConnectionField(RoleConnection)
+    all_roles = SQLAlchemyConnectionField(Role)
     # Disable sorting over this field
-    all_departments = SQLAlchemyConnectionField(DepartmentConnection, sort=None)
+    all_departments = SQLAlchemyConnectionField(Department, sort=None)
 
 
 schema = graphene.Schema(query=Query, types=[Department, Employee, Role])


### PR DESCRIPTION
Fix #190 

The flask example were also broken by useless `EmployeeConnection` class conflicting with the class automatically created by graphene-sqlalchemy due to the back-populate from department to employees