### PR TITLE
Release 2.1.2 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+## Local Development
+
+Set up our development dependencies:
+
+```sh
+pip install -e ".[dev]"
+pre-commit install
+```
+
+We use `tox` to test this library against different versions of `python` and `SQLAlchemy`.
+While developping locally, it is usually fine to run the tests against the most recent versions:
+
+```sh
+tox -e py37  # Python 3.7, SQLAlchemy < 2.0
+tox -e py37 -- -v -s  # Verbose output
+tox -e py37 -- -k test_query  # Only test_query.py
+```
+
+Our linters will run automatically when committing via git hooks but you can also run them manually:
+
+```sh
+tox -e pre-commit
+```
+
+## Release Process
+
+1. Update the version number in graphene_sqlalchemy/__init__.py via a PR.
+
+2. Once the PR is merged, tag the commit on master with the new version (only maintainers of the repo can do this). For example, "v2.1.2". Travis will then automatically build this tag and release it to Pypi.
+
+3. Make sure to create a new release on github (via the release tab) that lists all the changes that went into the new version.

--- a/README.md
+++ b/README.md
@@ -111,24 +111,4 @@ To learn more check out the following [examples](examples/):
 
 ## Contributing
 
-Set up our development dependencies:
-
-```sh
-pip install -e ".[dev]"
-pre-commit install  
-```
-
-We use `tox` to test this library against different versions of `python` and `SQLAlchemy`.
-While developping locally, it is usually fine to run the tests against the most recent versions:
-
-```sh
-tox -e py37  # Python 3.7, SQLAlchemy < 2.0
-tox -e py37 -- -v -s  # Verbose output
-tox -e py37 -- -k test_query  # Only test_query.py 
-```
-
-Our linters will run automatically when committing via git hooks but you can also run them manually:
-
-```sh
-tox -e pre-commit
-```
+See [CONTRIBUTING.md](/CONTRIBUTING.md)

--- a/graphene_sqlalchemy/__init__.py
+++ b/graphene_sqlalchemy/__init__.py
@@ -2,7 +2,7 @@ from .types import SQLAlchemyObjectType
 from .fields import SQLAlchemyConnectionField
 from .utils import get_query, get_session
 
-__version__ = "2.1.1"
+__version__ = "2.1.2"
 
 __all__ = [
     "__version__",


### PR DESCRIPTION
Release https://github.com/graphql-python/graphene-sqlalchemy/pull/187.

Also add documentation for the release process.

Btw we should decide as a group if we want to follow Semver or if we want to somehow track `graphene` version. I'm in favor of the former but it seems we are currently following the latter.