### PR TITLE
Improve creation of column and sort enums

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ __pycache__/
 # Distribution / packaging
 .Python
 env/
+.venv/
 build/
 develop-eggs/
 dist/

--- a/examples/flask_sqlalchemy/app.py
+++ b/examples/flask_sqlalchemy/app.py
@@ -1,43 +1,46 @@
 #!/usr/bin/env python
 
+from database import db_session, init_db
 from flask import Flask
+from schema import schema
 
 from flask_graphql import GraphQLView
-
-from .database import db_session, init_db
-from .schema import schema
 
 app = Flask(__name__)
 app.debug = True
 
-default_query = '''
+example_query = """
 {
-  allEmployees {
+  allEmployees(sort: [NAME_ASC, ID_ASC]) {
     edges {
       node {
-        id,
-        name,
+        id
+        name
         department {
-          id,
+          id
           name
-        },
+        }
         role {
-          id,
+          id
           name
         }
       }
     }
   }
-}'''.strip()
+}
+"""
 
 
-app.add_url_rule('/graphql', view_func=GraphQLView.as_view('graphql', schema=schema, graphiql=True))
+app.add_url_rule(
+    "/graphql", view_func=GraphQLView.as_view("graphql", schema=schema, graphiql=True)
+)
 
 
 @app.teardown_appcontext
 def shutdown_session(exception=None):
     db_session.remove()
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     init_db()
     app.run()

--- a/examples/flask_sqlalchemy/database.py
+++ b/examples/flask_sqlalchemy/database.py
@@ -14,7 +14,7 @@ def init_db():
     # import all modules here that might define models so that
     # they will be registered properly on the metadata.  Otherwise
     # you will have to import them first before calling init_db()
-    from .models import Department, Employee, Role
+    from models import Department, Employee, Role
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
 

--- a/examples/flask_sqlalchemy/models.py
+++ b/examples/flask_sqlalchemy/models.py
@@ -1,7 +1,6 @@
+from database import Base
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import backref, relationship
-
-from .database import Base
 
 
 class Department(Base):

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -1,11 +1,10 @@
+from models import Department as DepartmentModel
+from models import Employee as EmployeeModel
+from models import Role as RoleModel
+
 import graphene
 from graphene import relay
-from graphene_sqlalchemy import (SQLAlchemyConnectionField,
-                                 SQLAlchemyObjectType, utils)
-
-from .models import Department as DepartmentModel
-from .models import Employee as EmployeeModel
-from .models import Role as RoleModel
+from graphene_sqlalchemy import SQLAlchemyConnectionField, SQLAlchemyObjectType
 
 
 class Department(SQLAlchemyObjectType):
@@ -26,18 +25,11 @@ class Role(SQLAlchemyObjectType):
         interfaces = (relay.Node, )
 
 
-SortEnumEmployee = utils.sort_enum_for_model(EmployeeModel, 'SortEnumEmployee',
-    lambda c, d: c.upper() + ('_ASC' if d else '_DESC'))
-
-
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
     # Allow only single column sorting
     all_employees = SQLAlchemyConnectionField(
-        Employee,
-        sort=graphene.Argument(
-            SortEnumEmployee,
-            default_value=utils.EnumValue('id_asc', EmployeeModel.id.asc())))
+        Employee, sort=Employee.sort_argument())
     # Allows sorting over multiple columns, by default over the primary key
     all_roles = SQLAlchemyConnectionField(Role)
     # Disable sorting over this field

--- a/graphene_sqlalchemy/enums.py
+++ b/graphene_sqlalchemy/enums.py
@@ -1,0 +1,203 @@
+from sqlalchemy import Column
+from sqlalchemy.types import Enum as SQLAlchemyEnumType
+
+from graphene import Argument, Enum, List
+
+from .utils import EnumValue, to_enum_value_name, to_type_name
+
+
+def _convert_sa_to_graphene_enum(sa_enum, fallback_name=None):
+    """Convert the given SQLAlchemy Enum type to a Graphene Enum type.
+
+    The name of the Graphene Enum will be determined as follows:
+    If the SQLAlchemy Enum is based on a Python Enum, use the name
+    of the Python Enum.  Otherwise, if the SQLAlchemy Enum is named,
+    use the SQL name after conversion to a type name. Otherwise, use
+    the given fallback_name or raise an error if it is empty.
+
+    The Enum value names are converted to upper case if necessary.
+    """
+    if not isinstance(sa_enum, SQLAlchemyEnumType):
+        raise TypeError(
+            "Expected sqlalchemy.types.Enum, but got: {!r}".format(sa_enum)
+        )
+    enum_class = sa_enum.enum_class
+    if enum_class:
+        if all(to_enum_value_name(key) == key for key in enum_class.__members__):
+            return Enum.from_enum(enum_class)
+        name = enum_class.__name__
+        members = [
+            (to_enum_value_name(key), value.value)
+            for key, value in enum_class.__members__.items()
+        ]
+    else:
+        sql_enum_name = sa_enum.name
+        if sql_enum_name:
+            name = to_type_name(sql_enum_name)
+        elif fallback_name:
+            name = fallback_name
+        else:
+            raise TypeError("No type name specified for {!r}".format(sa_enum))
+        members = [(to_enum_value_name(key), key) for key in sa_enum.enums]
+    return Enum(name, members)
+
+
+def enum_for_sa_enum(sa_enum, registry):
+    """Return the Graphene Enum type for the specified SQLAlchemy Enum type."""
+    if not isinstance(sa_enum, SQLAlchemyEnumType):
+        raise TypeError(
+            "Expected sqlalchemy.types.Enum, but got: {!r}".format(sa_enum)
+        )
+    enum = registry.get_graphene_enum_for_sa_enum(sa_enum)
+    if not enum:
+        enum = _convert_sa_to_graphene_enum(sa_enum)
+        registry.register_enum(sa_enum, enum)
+    return enum
+
+
+def enum_for_field(obj_type, field_name):
+    """Return the Graphene Enum type for the specified Graphene field."""
+    from .types import SQLAlchemyObjectType
+
+    if not isinstance(obj_type, type) or not issubclass(obj_type, SQLAlchemyObjectType):
+        raise TypeError(
+            "Expected SQLAlchemyObjectType, but got: {!r}".format(obj_type))
+    if not field_name or not isinstance(field_name, str):
+        raise TypeError(
+            "Expected a field name, but got: {!r}".format(field_name))
+    registry = obj_type._meta.registry
+    orm_field = registry.get_orm_field_for_graphene_field(obj_type, field_name)
+    if orm_field is None:
+        raise TypeError("Cannot get {}.{}".format(obj_type._meta.name, field_name))
+    if not isinstance(orm_field, Column):
+        raise TypeError(
+            "{}.{} does not map to model column".format(obj_type._meta.name, field_name)
+        )
+    sa_enum = orm_field.type
+    if not isinstance(sa_enum, SQLAlchemyEnumType):
+        raise TypeError(
+            "{}.{} does not map to enum column".format(obj_type._meta.name, field_name)
+        )
+    enum = registry.get_graphene_enum_for_sa_enum(sa_enum)
+    if not enum:
+        fallback_name = obj_type._meta.name + to_type_name(field_name)
+        enum = _convert_sa_to_graphene_enum(sa_enum, fallback_name)
+        registry.register_enum(sa_enum, enum)
+    return enum
+
+
+def _default_sort_enum_symbol_name(column_name, sort_asc=True):
+    return to_enum_value_name(column_name) + ("_ASC" if sort_asc else "_DESC")
+
+
+def sort_enum_for_object_type(
+    obj_type, name=None, only_fields=None, only_indexed=None, get_symbol_name=None
+):
+    """Return Graphene Enum for sorting the given SQLAlchemyObjectType.
+
+    Parameters
+    - obj_type : SQLAlchemyObjectType
+        The object type for which the sort Enum shall be generated.
+    - name : str, optional, default None
+        Name to use for the sort Enum.
+        If not provided, it will be set to the object type name + 'SortEnum'
+    - only_fields : sequence, optional, default None
+        If this is set, only fields from this sequence will be considered.
+    - only_indexed : bool, optional, default False
+        If this is set, only indexed columns will be considered.
+    - get_symbol_name : function, optional, default None
+        Function which takes the column name and a boolean indicating
+        if the sort direction is ascending, and returns the symbol name
+        for the current column and sort direction. If no such function
+        is passed, a default function will be used that creates the symbols
+        'foo_asc' and 'foo_desc' for a column with the name 'foo'.
+
+    Returns
+    - Enum
+        The Graphene Enum type
+    """
+    name = name or obj_type._meta.name + "SortEnum"
+    registry = obj_type._meta.registry
+    enum = registry.get_sort_enum_for_object_type(obj_type)
+    custom_options = dict(
+        only_fields=only_fields,
+        only_indexed=only_indexed,
+        get_symbol_name=get_symbol_name,
+    )
+    if enum:
+        if name != enum.__name__ or custom_options != enum.custom_options:
+            raise ValueError(
+                "Sort enum for {} has already been customized".format(obj_type)
+            )
+    else:
+        members = []
+        default = []
+        fields = obj_type._meta.fields
+        get_name = get_symbol_name or _default_sort_enum_symbol_name
+        for field_name in fields:
+            if only_fields and field_name not in only_fields:
+                continue
+            orm_field = registry.get_orm_field_for_graphene_field(obj_type, field_name)
+            if not isinstance(orm_field, Column):
+                continue
+            if only_indexed and not (orm_field.primary_key or orm_field.index):
+                continue
+            asc_name = get_name(orm_field.name, True)
+            asc_value = EnumValue(asc_name, orm_field.asc())
+            desc_name = get_name(orm_field.name, False)
+            desc_value = EnumValue(desc_name, orm_field.desc())
+            if orm_field.primary_key:
+                default.append(asc_value)
+            members.extend(((asc_name, asc_value), (desc_name, desc_value)))
+        enum = Enum(name, members)
+        enum.default = default  # store default as attribute
+        enum.custom_options = custom_options
+        registry.register_sort_enum(obj_type, enum)
+    return enum
+
+
+def sort_argument_for_object_type(
+    obj_type,
+    enum_name=None,
+    only_fields=None,
+    only_indexed=None,
+    get_symbol_name=None,
+    has_default=True,
+):
+    """"Returns Graphene Argument for sorting the given SQLAlchemyObjectType.
+
+    Parameters
+    - obj_type : SQLAlchemyObjectType
+        The object type for which the sort Argument shall be generated.
+    - enum_name : str, optional, default None
+        Name to use for the sort Enum.
+        If not provided, it will be set to the object type name + 'SortEnum'
+    - only_fields : sequence, optional, default None
+        If this is set, only fields from this sequence will be considered.
+    - only_indexed : bool, optional, default False
+        If this is set, only indexed columns will be considered.
+    - get_symbol_name : function, optional, default None
+        Function which takes the column name and a boolean indicating
+        if the sort direction is ascending, and returns the symbol name
+        for the current column and sort direction. If no such function
+        is passed, a default function will be used that creates the symbols
+        'foo_asc' and 'foo_desc' for a column with the name 'foo'.
+    - has_default : bool, optional, default True
+        If this is set to False, no sorting will happen when this argument is not
+        passed. Otherwise results will be sortied by the primary key(s) of the model.
+
+    Returns
+    - Enum
+        A Graphene Argument that accepts a list of sorting directions for the model.
+    """
+    enum = sort_enum_for_object_type(
+        obj_type,
+        enum_name,
+        only_fields=only_fields,
+        only_indexed=only_indexed,
+        get_symbol_name=get_symbol_name,
+    )
+    if not has_default:
+        enum.default = None
+
+    return Argument(List(enum), default_value=enum.default)

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -8,7 +8,7 @@ from graphene.relay import Connection, ConnectionField
 from graphene.relay.connection import PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
 
-from .utils import get_query, sort_argument_for_model
+from .utils import get_query
 
 log = logging.getLogger()
 
@@ -84,10 +84,9 @@ class SQLAlchemyConnectionField(UnsortedSQLAlchemyConnectionField):
         if "sort" not in kwargs and issubclass(type, Connection):
             # Let super class raise if type is not a Connection
             try:
-                model = type.Edge.node._type._meta.model
-                kwargs.setdefault("sort", sort_argument_for_model(model))
-            except Exception:
-                raise Exception(
+                kwargs.setdefault("sort", type.Edge.node._type.sort_argument())
+            except (AttributeError, TypeError):
+                raise TypeError(
                     'Cannot create sort argument for {}. A model is required. Set the "sort" argument'
                     " to None to disabling the creation of the sort query argument".format(
                         type.__name__
@@ -109,7 +108,7 @@ __connectionFactory = UnsortedSQLAlchemyConnectionField
 
 
 def createConnectionField(_type):
-    log.warn(
+    log.warning(
         'createConnectionField is deprecated and will be removed in the next '
         'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.'
     )
@@ -117,7 +116,7 @@ def createConnectionField(_type):
 
 
 def registerConnectionFieldFactory(factoryMethod):
-    log.warn(
+    log.warning(
         'registerConnectionFieldFactory is deprecated and will be removed in the next '
         'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.'
     )
@@ -126,7 +125,7 @@ def registerConnectionFieldFactory(factoryMethod):
 
 
 def unregisterConnectionFieldFactory():
-    log.warn(
+    log.warning(
         'registerConnectionFieldFactory is deprecated and will be removed in the next '
         'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.'
     )

--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -1,31 +1,90 @@
+from collections import defaultdict
+
+from sqlalchemy.types import Enum as SQLAlchemyEnumType
+
+from graphene import Enum
+
+
 class Registry(object):
     def __init__(self):
         self._registry = {}
         self._registry_models = {}
+        self._registry_orm_fields = defaultdict(dict)
         self._registry_composites = {}
+        self._registry_enums = {}
+        self._registry_sort_enums = {}
 
-    def register(self, cls):
+    def register(self, obj_type):
         from .types import SQLAlchemyObjectType
 
-        assert issubclass(cls, SQLAlchemyObjectType), (
-            "Only classes of type SQLAlchemyObjectType can be registered, "
-            'received "{}"'
-        ).format(cls.__name__)
-        assert cls._meta.registry == self, "Registry for a Model have to match."
+        if not isinstance(obj_type, type) or not issubclass(
+            obj_type, SQLAlchemyObjectType
+        ):
+            raise TypeError(
+                "Expected SQLAlchemyObjectType, but got: {!r}".format(obj_type)
+            )
+        assert obj_type._meta.registry == self, "Registry for a Model have to match."
         # assert self.get_type_for_model(cls._meta.model) in [None, cls], (
         #     'SQLAlchemy model "{}" already associated with '
         #     'another type "{}".'
         # ).format(cls._meta.model, self._registry[cls._meta.model])
-        self._registry[cls._meta.model] = cls
+        self._registry[obj_type._meta.model] = obj_type
 
     def get_type_for_model(self, model):
         return self._registry.get(model)
+
+    def register_orm_field(self, obj_type, field_name, orm_field):
+        from .types import SQLAlchemyObjectType
+
+        if not isinstance(obj_type, type) or not issubclass(
+            obj_type, SQLAlchemyObjectType
+        ):
+            raise TypeError(
+                "Expected SQLAlchemyObjectType, but got: {!r}".format(obj_type)
+            )
+        if not field_name or not isinstance(field_name, str):
+            raise TypeError("Expected a field name, but got: {!r}".format(field_name))
+        self._registry_orm_fields[obj_type][field_name] = orm_field
+
+    def get_orm_field_for_graphene_field(self, obj_type, field_name):
+        return self._registry_orm_fields.get(obj_type, {}).get(field_name)
 
     def register_composite_converter(self, composite, converter):
         self._registry_composites[composite] = converter
 
     def get_converter_for_composite(self, composite):
         return self._registry_composites.get(composite)
+
+    def register_enum(self, sa_enum, graphene_enum):
+        if not isinstance(sa_enum, SQLAlchemyEnumType):
+            raise TypeError(
+                "Expected SQLAlchemyEnumType, but got: {!r}".format(sa_enum)
+            )
+        if not isinstance(graphene_enum, type(Enum)):
+            raise TypeError(
+                "Expected Graphene Enum, but got: {!r}".format(graphene_enum)
+            )
+
+        self._registry_enums[sa_enum] = graphene_enum
+
+    def get_graphene_enum_for_sa_enum(self, sa_enum):
+        return self._registry_enums.get(sa_enum)
+
+    def register_sort_enum(self, obj_type, sort_enum):
+        from .types import SQLAlchemyObjectType
+
+        if not isinstance(obj_type, type) or not issubclass(
+            obj_type, SQLAlchemyObjectType
+        ):
+            raise TypeError(
+                "Expected SQLAlchemyObjectType, but got: {!r}".format(obj_type)
+            )
+        if not isinstance(sort_enum, type(Enum)):
+            raise TypeError("Expected Graphene Enum, but got: {!r}".format(sort_enum))
+        self._registry_sort_enums[obj_type] = sort_enum
+
+    def get_sort_enum_for_object_type(self, obj_type):
+        return self._registry_sort_enums.get(obj_type)
 
 
 registry = None

--- a/graphene_sqlalchemy/tests/conftest.py
+++ b/graphene_sqlalchemy/tests/conftest.py
@@ -1,0 +1,32 @@
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+
+from ..registry import reset_global_registry
+from .models import Base
+
+test_db_url = 'sqlite://'  # use in-memory database for tests
+
+
+@pytest.fixture(autouse=True)
+def reset_registry():
+    reset_global_registry()
+
+
+@pytest.yield_fixture(scope="function")
+def session():
+    db = create_engine(test_db_url)
+    connection = db.engine.connect()
+    transaction = connection.begin()
+    Base.metadata.create_all(connection)
+
+    # options = dict(bind=connection, binds={})
+    session_factory = sessionmaker(bind=connection)
+    session = scoped_session(session_factory)
+
+    yield session
+
+    # Finalize test here
+    transaction.rollback()
+    connection.close()
+    session.remove()

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -6,8 +6,10 @@ from sqlalchemy import Column, Date, Enum, ForeignKey, Integer, String, Table
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import mapper, relationship
 
+PetKind = Enum("cat", "dog", name="pet_kind")
 
-class Hairkind(enum.Enum):
+
+class HairKind(enum.Enum):
     LONG = 'long'
     SHORT = 'short'
 
@@ -32,8 +34,8 @@ class Pet(Base):
     __tablename__ = "pets"
     id = Column(Integer(), primary_key=True)
     name = Column(String(30))
-    pet_kind = Column(Enum("cat", "dog", name="pet_kind"), nullable=False)
-    hair_kind = Column(Enum(Hairkind, name="hair_kind"), nullable=False)
+    pet_kind = Column(PetKind, nullable=False)
+    hair_kind = Column(Enum(HairKind, name="hair_kind"), nullable=False)
     reporter_id = Column(Integer(), ForeignKey("reporters.id"))
 
 
@@ -43,6 +45,7 @@ class Reporter(Base):
     first_name = Column(String(30))
     last_name = Column(String(30))
     email = Column(String())
+    favorite_pet_kind = Column(PetKind)
     pets = relationship("Pet", secondary=association_table, backref="reporters")
     articles = relationship("Article", backref="reporter")
     favorite_article = relationship("Article", uselist=False)

--- a/graphene_sqlalchemy/tests/test_enums.py
+++ b/graphene_sqlalchemy/tests/test_enums.py
@@ -1,0 +1,122 @@
+from enum import Enum as PyEnum
+
+import pytest
+from sqlalchemy.types import Enum as SQLAlchemyEnumType
+
+from graphene import Enum
+
+from ..enums import _convert_sa_to_graphene_enum, enum_for_field
+from ..types import SQLAlchemyObjectType
+from .models import HairKind, Pet
+
+
+def test_convert_sa_to_graphene_enum_bad_type():
+    re_err = "Expected sqlalchemy.types.Enum, but got: 'foo'"
+    with pytest.raises(TypeError, match=re_err):
+        _convert_sa_to_graphene_enum("foo")
+
+
+def test_convert_sa_to_graphene_enum_based_on_py_enum():
+    class Color(PyEnum):
+        RED = 1
+        GREEN = 2
+        BLUE = 3
+
+    sa_enum = SQLAlchemyEnumType(Color)
+    graphene_enum = _convert_sa_to_graphene_enum(sa_enum, "FallbackName")
+    assert isinstance(graphene_enum, type(Enum))
+    assert graphene_enum._meta.name == "Color"
+    assert graphene_enum._meta.enum is Color
+
+
+def test_convert_sa_to_graphene_enum_based_on_py_enum_with_bad_names():
+    class Color(PyEnum):
+        red = 1
+        green = 2
+        blue = 3
+
+    sa_enum = SQLAlchemyEnumType(Color)
+    graphene_enum = _convert_sa_to_graphene_enum(sa_enum, "FallbackName")
+    assert isinstance(graphene_enum, type(Enum))
+    assert graphene_enum._meta.name == "Color"
+    assert graphene_enum._meta.enum is not Color
+    assert [
+        (key, value.value)
+        for key, value in graphene_enum._meta.enum.__members__.items()
+    ] == [("RED", 1), ("GREEN", 2), ("BLUE", 3)]
+
+
+def test_convert_sa_enum_to_graphene_enum_based_on_list_named():
+    sa_enum = SQLAlchemyEnumType("red", "green", "blue", name="color_values")
+    graphene_enum = _convert_sa_to_graphene_enum(sa_enum, "FallbackName")
+    assert isinstance(graphene_enum, type(Enum))
+    assert graphene_enum._meta.name == "ColorValues"
+    assert [
+        (key, value.value)
+        for key, value in graphene_enum._meta.enum.__members__.items()
+    ] == [("RED", 'red'), ("GREEN", 'green'), ("BLUE", 'blue')]
+
+
+def test_convert_sa_enum_to_graphene_enum_based_on_list_unnamed():
+    sa_enum = SQLAlchemyEnumType("red", "green", "blue")
+    graphene_enum = _convert_sa_to_graphene_enum(sa_enum, "FallbackName")
+    assert isinstance(graphene_enum, type(Enum))
+    assert graphene_enum._meta.name == "FallbackName"
+    assert [
+        (key, value.value)
+        for key, value in graphene_enum._meta.enum.__members__.items()
+    ] == [("RED", 'red'), ("GREEN", 'green'), ("BLUE", 'blue')]
+
+
+def test_convert_sa_enum_to_graphene_enum_based_on_list_without_name():
+    sa_enum = SQLAlchemyEnumType("red", "green", "blue")
+    re_err = r"No type name specified for Enum\('red', 'green', 'blue'\)"
+    with pytest.raises(TypeError, match=re_err):
+        _convert_sa_to_graphene_enum(sa_enum)
+
+
+def test_enum_for_field():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    enum = enum_for_field(PetType, 'pet_kind')
+    assert isinstance(enum, type(Enum))
+    assert enum._meta.name == "PetKind"
+    assert [
+        (key, value.value)
+        for key, value in enum._meta.enum.__members__.items()
+    ] == [("CAT", 'cat'), ("DOG", 'dog')]
+    enum2 = enum_for_field(PetType, 'pet_kind')
+    assert enum2 is enum
+    enum2 = PetType.enum_for_field('pet_kind')
+    assert enum2 is enum
+
+    enum = enum_for_field(PetType, 'hair_kind')
+    assert isinstance(enum, type(Enum))
+    assert enum._meta.name == "HairKind"
+    assert enum._meta.enum is HairKind
+    enum2 = PetType.enum_for_field('hair_kind')
+    assert enum2 is enum
+
+    re_err = r"Cannot get PetType\.other_kind"
+    with pytest.raises(TypeError, match=re_err):
+        enum_for_field(PetType, 'other_kind')
+    with pytest.raises(TypeError, match=re_err):
+        PetType.enum_for_field('other_kind')
+
+    re_err = r"PetType\.name does not map to enum column"
+    with pytest.raises(TypeError, match=re_err):
+        enum_for_field(PetType, 'name')
+    with pytest.raises(TypeError, match=re_err):
+        PetType.enum_for_field('name')
+
+    re_err = r"Expected a field name, but got: None"
+    with pytest.raises(TypeError, match=re_err):
+        enum_for_field(PetType, None)
+    with pytest.raises(TypeError, match=re_err):
+        PetType.enum_for_field(None)
+
+    re_err = "Expected SQLAlchemyObjectType, but got: None"
+    with pytest.raises(TypeError, match=re_err):
+        enum_for_field(None, 'other_kind')

--- a/graphene_sqlalchemy/tests/test_fields.py
+++ b/graphene_sqlalchemy/tests/test_fields.py
@@ -4,8 +4,7 @@ from graphene.relay import Connection
 
 from ..fields import SQLAlchemyConnectionField
 from ..types import SQLAlchemyObjectType
-from ..utils import sort_argument_for_model
-from .models import Editor
+from .models import Editor as EditorModel
 from .models import Pet as PetModel
 
 
@@ -14,27 +13,32 @@ class Pet(SQLAlchemyObjectType):
         model = PetModel
 
 
+class Editor(SQLAlchemyObjectType):
+    class Meta:
+        model = EditorModel
+
+
 class PetConn(Connection):
     class Meta:
         node = Pet
 
 
 def test_sort_added_by_default():
-    arg = SQLAlchemyConnectionField(PetConn)
-    assert "sort" in arg.args
-    assert arg.args["sort"] == sort_argument_for_model(PetModel)
+    field = SQLAlchemyConnectionField(PetConn)
+    assert "sort" in field.args
+    assert field.args["sort"] == Pet.sort_argument()
 
 
 def test_sort_can_be_removed():
-    arg = SQLAlchemyConnectionField(PetConn, sort=None)
-    assert "sort" not in arg.args
+    field = SQLAlchemyConnectionField(PetConn, sort=None)
+    assert "sort" not in field.args
 
 
 def test_custom_sort():
-    arg = SQLAlchemyConnectionField(PetConn, sort=sort_argument_for_model(Editor))
-    assert arg.args["sort"] == sort_argument_for_model(Editor)
+    field = SQLAlchemyConnectionField(PetConn, sort=Editor.sort_argument())
+    assert field.args["sort"] == Editor.sort_argument()
 
 
 def test_init_raises():
-    with pytest.raises(Exception, match="Cannot create sort"):
+    with pytest.raises(TypeError, match="Cannot create sort"):
         SQLAlchemyConnectionField(Connection)

--- a/graphene_sqlalchemy/tests/test_query.py
+++ b/graphene_sqlalchemy/tests/test_query.py
@@ -1,55 +1,44 @@
-import pytest
-from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
-
 import graphene
 from graphene.relay import Connection, Node
 
 from ..fields import SQLAlchemyConnectionField
-from ..registry import reset_global_registry
 from ..types import SQLAlchemyObjectType
-from ..utils import sort_argument_for_model, sort_enum_for_model
-from .models import Article, Base, Editor, Hairkind, Pet, Reporter
-
-db = create_engine("sqlite:///test_sqlalchemy.sqlite3")
+from .models import Article, Editor, HairKind, Pet, Reporter
 
 
-@pytest.yield_fixture(scope="function")
-def session():
-    reset_global_registry()
-    connection = db.engine.connect()
-    transaction = connection.begin()
-    Base.metadata.create_all(connection)
-
-    # options = dict(bind=connection, binds={})
-    session_factory = sessionmaker(bind=connection)
-    session = scoped_session(session_factory)
-
-    yield session
-
-    # Finalize test here
-    transaction.rollback()
-    connection.close()
-    session.remove()
+def to_std_dicts(value):
+    """Convert nested ordered dicts to normal dicts for better comparison."""
+    if isinstance(value, dict):
+        return {k: to_std_dicts(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [to_std_dicts(v) for v in value]
+    else:
+        return value
 
 
-def setup_fixtures(session):
-    pet = Pet(name="Lassie", pet_kind="dog", hair_kind=Hairkind.LONG)
-    session.add(pet)
-    reporter = Reporter(first_name="ABA", last_name="X")
+def add_test_data(session):
+    reporter = Reporter(
+        first_name='John', last_name='Doe', favorite_pet_kind='cat')
     session.add(reporter)
-    reporter2 = Reporter(first_name="ABO", last_name="Y")
-    session.add(reporter2)
-    article = Article(headline="Hi!")
+    pet = Pet(name='Garfield', pet_kind='cat', hair_kind=HairKind.SHORT)
+    session.add(pet)
+    pet.reporters.append(reporter)
+    article = Article(headline='Hi!')
     article.reporter = reporter
     session.add(article)
-    editor = Editor(name="John")
+    reporter = Reporter(
+        first_name='Jane', last_name='Roe', favorite_pet_kind='dog')
+    session.add(reporter)
+    pet = Pet(name='Lassie', pet_kind='dog', hair_kind=HairKind.LONG)
+    pet.reporters.append(reporter)
+    session.add(pet)
+    editor = Editor(name="Jack")
     session.add(editor)
     session.commit()
 
 
 def test_should_query_well(session):
-    setup_fixtures(session)
+    add_test_data(session)
 
     class ReporterType(SQLAlchemyObjectType):
         class Meta:
@@ -59,17 +48,17 @@ def test_should_query_well(session):
         reporter = graphene.Field(ReporterType)
         reporters = graphene.List(ReporterType)
 
-        def resolve_reporter(self, *args, **kwargs):
+        def resolve_reporter(self, _info):
             return session.query(Reporter).first()
 
-        def resolve_reporters(self, *args, **kwargs):
+        def resolve_reporters(self, _info):
             return session.query(Reporter)
 
     query = """
         query ReporterQuery {
           reporter {
-            firstName,
-            lastName,
+            firstName
+            lastName
             email
           }
           reporters {
@@ -78,117 +67,18 @@ def test_should_query_well(session):
         }
     """
     expected = {
-        "reporter": {"firstName": "ABA", "lastName": "X", "email": None},
-        "reporters": [{"firstName": "ABA"}, {"firstName": "ABO"}],
+        "reporter": {"firstName": "John", "lastName": "Doe", "email": None},
+        "reporters": [{"firstName": "John"}, {"firstName": "Jane"}],
     }
     schema = graphene.Schema(query=Query)
     result = schema.execute(query)
     assert not result.errors
-    assert result.data == expected
+    result = to_std_dicts(result.data)
+    assert result == expected
 
 
-def test_should_query_enums(session):
-    setup_fixtures(session)
-
-    class PetType(SQLAlchemyObjectType):
-        class Meta:
-            model = Pet
-
-    class Query(graphene.ObjectType):
-        pet = graphene.Field(PetType)
-
-        def resolve_pet(self, *args, **kwargs):
-            return session.query(Pet).first()
-
-    query = """
-        query PetQuery {
-          pet {
-            name,
-            petKind
-            hairKind
-          }
-        }
-    """
-    expected = {"pet": {"name": "Lassie", "petKind": "dog", "hairKind": "LONG"}}
-    schema = graphene.Schema(query=Query)
-    result = schema.execute(query)
-    assert not result.errors
-    assert result.data == expected, result.data
-
-
-def test_enum_parameter(session):
-    setup_fixtures(session)
-
-    class PetType(SQLAlchemyObjectType):
-        class Meta:
-            model = Pet
-
-    class Query(graphene.ObjectType):
-        pet = graphene.Field(PetType, kind=graphene.Argument(PetType._meta.fields['pet_kind'].type.of_type))
-
-        def resolve_pet(self, info, kind=None, *args, **kwargs):
-            query = session.query(Pet)
-            if kind:
-                query = query.filter(Pet.pet_kind == kind)
-            return query.first()
-
-    query = """
-        query PetQuery($kind: pet_kind) {
-          pet(kind: $kind) {
-            name,
-            petKind
-            hairKind
-          }
-        }
-    """
-    expected = {"pet": {"name": "Lassie", "petKind": "dog", "hairKind": "LONG"}}
-    schema = graphene.Schema(query=Query)
-    result = schema.execute(query, variables={"kind": "cat"})
-    assert not result.errors
-    assert result.data == {"pet": None}
-    result = schema.execute(query, variables={"kind": "dog"})
-    assert not result.errors
-    assert result.data == expected, result.data
-
-
-def test_py_enum_parameter(session):
-    setup_fixtures(session)
-
-    class PetType(SQLAlchemyObjectType):
-        class Meta:
-            model = Pet
-
-    class Query(graphene.ObjectType):
-        pet = graphene.Field(PetType, kind=graphene.Argument(PetType._meta.fields['hair_kind'].type.of_type))
-
-        def resolve_pet(self, info, kind=None, *args, **kwargs):
-            query = session.query(Pet)
-            if kind:
-                # XXX Why kind passed in as a str instead of a Hairkind instance?
-                query = query.filter(Pet.hair_kind == Hairkind(kind))
-            return query.first()
-
-    query = """
-        query PetQuery($kind: Hairkind) {
-          pet(kind: $kind) {
-            name,
-            petKind
-            hairKind
-          }
-        }
-    """
-    expected = {"pet": {"name": "Lassie", "petKind": "dog", "hairKind": "LONG"}}
-    schema = graphene.Schema(query=Query)
-    result = schema.execute(query, variables={"kind": "SHORT"})
-    assert not result.errors
-    assert result.data == {"pet": None}
-    result = schema.execute(query, variables={"kind": "LONG"})
-    assert not result.errors
-    assert result.data == expected, result.data
-
-
-def test_should_node(session):
-    setup_fixtures(session)
+def test_should_query_node(session):
+    add_test_data(session)
 
     class ReporterNode(SQLAlchemyObjectType):
         class Meta:
@@ -204,10 +94,6 @@ def test_should_node(session):
             model = Article
             interfaces = (Node,)
 
-        # @classmethod
-        # def get_node(cls, id, info):
-        #     return Article(id=1, headline='Article node')
-
     class ArticleConnection(Connection):
         class Meta:
             node = ArticleNode
@@ -218,16 +104,16 @@ def test_should_node(session):
         article = graphene.Field(ArticleNode)
         all_articles = SQLAlchemyConnectionField(ArticleConnection)
 
-        def resolve_reporter(self, *args, **kwargs):
+        def resolve_reporter(self, _info):
             return session.query(Reporter).first()
 
-        def resolve_article(self, *args, **kwargs):
+        def resolve_article(self, _info):
             return session.query(Article).first()
 
     query = """
         query ReporterQuery {
           reporter {
-            id,
+            id
             firstName,
             articles {
               edges {
@@ -260,8 +146,8 @@ def test_should_node(session):
     expected = {
         "reporter": {
             "id": "UmVwb3J0ZXJOb2RlOjE=",
-            "firstName": "ABA",
-            "lastName": "X",
+            "firstName": "John",
+            "lastName": "Doe",
             "email": None,
             "articles": {"edges": [{"node": {"headline": "Hi!"}}]},
         },
@@ -271,11 +157,12 @@ def test_should_node(session):
     schema = graphene.Schema(query=Query)
     result = schema.execute(query, context_value={"session": session})
     assert not result.errors
-    assert result.data == expected
+    result = to_std_dicts(result.data)
+    assert result == expected
 
 
 def test_should_custom_identifier(session):
-    setup_fixtures(session)
+    add_test_data(session)
 
     class EditorNode(SQLAlchemyObjectType):
         class Meta:
@@ -295,7 +182,7 @@ def test_should_custom_identifier(session):
           allEditors {
             edges {
                 node {
-                    id,
+                    id
                     name
                 }
             }
@@ -308,18 +195,19 @@ def test_should_custom_identifier(session):
         }
     """
     expected = {
-        "allEditors": {"edges": [{"node": {"id": "RWRpdG9yTm9kZTox", "name": "John"}}]},
-        "node": {"name": "John"},
+        "allEditors": {"edges": [{"node": {"id": "RWRpdG9yTm9kZTox", "name": "Jack"}}]},
+        "node": {"name": "Jack"},
     }
 
     schema = graphene.Schema(query=Query)
     result = schema.execute(query, context_value={"session": session})
     assert not result.errors
-    assert result.data == expected
+    result = to_std_dicts(result.data)
+    assert result == expected
 
 
 def test_should_mutate_well(session):
-    setup_fixtures(session)
+    add_test_data(session)
 
     class EditorNode(SQLAlchemyObjectType):
         class Meta:
@@ -385,7 +273,7 @@ def test_should_mutate_well(session):
             "ok": True,
             "article": {
                 "headline": "My Article",
-                "reporter": {"id": "UmVwb3J0ZXJOb2RlOjE=", "firstName": "ABA"},
+                "reporter": {"id": "UmVwb3J0ZXJOb2RlOjE=", "firstName": "John"},
             },
         }
     }
@@ -393,165 +281,5 @@ def test_should_mutate_well(session):
     schema = graphene.Schema(query=Query, mutation=Mutation)
     result = schema.execute(query, context_value={"session": session})
     assert not result.errors
-    assert result.data == expected
-
-
-def sort_setup(session):
-    pets = [
-        Pet(id=2, name="Lassie", pet_kind="dog", hair_kind=Hairkind.LONG),
-        Pet(id=22, name="Alf", pet_kind="cat", hair_kind=Hairkind.LONG),
-        Pet(id=3, name="Barf", pet_kind="dog", hair_kind=Hairkind.LONG),
-    ]
-    session.add_all(pets)
-    session.commit()
-
-
-def test_sort(session):
-    sort_setup(session)
-
-    class PetNode(SQLAlchemyObjectType):
-        class Meta:
-            model = Pet
-            interfaces = (Node,)
-
-    class PetConnection(Connection):
-        class Meta:
-            node = PetNode
-
-    class Query(graphene.ObjectType):
-        defaultSort = SQLAlchemyConnectionField(PetConnection)
-        nameSort = SQLAlchemyConnectionField(PetConnection)
-        multipleSort = SQLAlchemyConnectionField(PetConnection)
-        descSort = SQLAlchemyConnectionField(PetConnection)
-        singleColumnSort = SQLAlchemyConnectionField(
-            PetConnection, sort=graphene.Argument(sort_enum_for_model(Pet))
-        )
-        noDefaultSort = SQLAlchemyConnectionField(
-            PetConnection, sort=sort_argument_for_model(Pet, False)
-        )
-        noSort = SQLAlchemyConnectionField(PetConnection, sort=None)
-
-    query = """
-        query sortTest {
-            defaultSort{
-                edges{
-                    node{
-                        id
-                    }
-                }
-            }
-            nameSort(sort: name_asc){
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-            multipleSort(sort: [pet_kind_asc, name_desc]){
-                edges{
-                    node{
-                        name
-                        petKind
-                    }
-                }
-            }
-            descSort(sort: [name_desc]){
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-            singleColumnSort(sort: name_desc){
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-            noDefaultSort(sort: name_asc){
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-        }
-    """
-
-    def makeNodes(nodeList):
-        nodes = [{"node": item} for item in nodeList]
-        return {"edges": nodes}
-
-    expected = {
-        "defaultSort": makeNodes(
-            [{"id": "UGV0Tm9kZToy"}, {"id": "UGV0Tm9kZToz"}, {"id": "UGV0Tm9kZToyMg=="}]
-        ),
-        "nameSort": makeNodes([{"name": "Alf"}, {"name": "Barf"}, {"name": "Lassie"}]),
-        "noDefaultSort": makeNodes(
-            [{"name": "Alf"}, {"name": "Barf"}, {"name": "Lassie"}]
-        ),
-        "multipleSort": makeNodes(
-            [
-                {"name": "Alf", "petKind": "cat"},
-                {"name": "Lassie", "petKind": "dog"},
-                {"name": "Barf", "petKind": "dog"},
-            ]
-        ),
-        "descSort": makeNodes([{"name": "Lassie"}, {"name": "Barf"}, {"name": "Alf"}]),
-        "singleColumnSort": makeNodes(
-            [{"name": "Lassie"}, {"name": "Barf"}, {"name": "Alf"}]
-        ),
-    }  # yapf: disable
-
-    schema = graphene.Schema(query=Query)
-    result = schema.execute(query, context_value={"session": session})
-    assert not result.errors
-    assert result.data == expected
-
-    queryError = """
-        query sortTest {
-            singleColumnSort(sort: [pet_kind_asc, name_desc]){
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-        }
-    """
-    result = schema.execute(queryError, context_value={"session": session})
-    assert result.errors is not None
-
-    queryNoSort = """
-        query sortTest {
-            noDefaultSort{
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-            noSort{
-                edges{
-                    node{
-                        name
-                    }
-                }
-            }
-        }
-    """
-
-    expectedNoSort = {
-        "noDefaultSort": makeNodes(
-            [{"name": "Alf"}, {"name": "Barf"}, {"name": "Lassie"}]
-        ),
-        "noSort": makeNodes([{"name": "Alf"}, {"name": "Barf"}, {"name": "Lassie"}]),
-    }  # yapf: disable
-
-    result = schema.execute(queryNoSort, context_value={"session": session})
-    assert not result.errors
-    for key, value in result.data.items():
-        assert set(node["node"]["name"] for node in value["edges"]) == set(
-            node["node"]["name"] for node in expectedNoSort[key]["edges"]
-        )
+    result = to_std_dicts(result.data)
+    assert result == expected

--- a/graphene_sqlalchemy/tests/test_query_enums.py
+++ b/graphene_sqlalchemy/tests/test_query_enums.py
@@ -1,0 +1,198 @@
+import graphene
+
+from ..types import SQLAlchemyObjectType
+from .models import HairKind, Pet, Reporter
+from .test_query import add_test_data, to_std_dicts
+
+
+def test_query_pet_kinds(session):
+    add_test_data(session)
+
+    class PetType(SQLAlchemyObjectType):
+
+        class Meta:
+            model = Pet
+
+    class ReporterType(SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+
+    class Query(graphene.ObjectType):
+        reporter = graphene.Field(ReporterType)
+        reporters = graphene.List(ReporterType)
+        pets = graphene.List(PetType, kind=graphene.Argument(
+            PetType.enum_for_field('pet_kind')))
+
+        def resolve_reporter(self, _info):
+            return session.query(Reporter).first()
+
+        def resolve_reporters(self, _info):
+            return session.query(Reporter)
+
+        def resolve_pets(self, _info, kind):
+            query = session.query(Pet)
+            if kind:
+                query = query.filter_by(pet_kind=kind)
+            return query
+
+    query = """
+        query ReporterQuery {
+          reporter {
+            firstName
+            lastName
+            email
+            favoritePetKind
+            pets {
+              name
+              petKind
+            }
+          }
+          reporters {
+            firstName
+            favoritePetKind
+          }
+          pets(kind: DOG) {
+            name
+            petKind
+          }
+        }
+    """
+    expected = {
+        'reporter': {
+            'firstName': 'John',
+            'lastName': 'Doe',
+            'email': None,
+            'favoritePetKind': 'CAT',
+            'pets': [{
+                'name': 'Garfield',
+                'petKind': 'CAT'
+            }]
+        },
+        'reporters': [{
+            'firstName': 'John',
+            'favoritePetKind': 'CAT',
+        }, {
+            'firstName': 'Jane',
+            'favoritePetKind': 'DOG',
+        }],
+        'pets': [{
+            'name': 'Lassie',
+            'petKind': 'DOG'
+        }]
+    }
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query)
+    assert not result.errors
+    assert result.data == expected
+
+
+def test_query_more_enums(session):
+    add_test_data(session)
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    class Query(graphene.ObjectType):
+        pet = graphene.Field(PetType)
+
+        def resolve_pet(self, _info):
+            return session.query(Pet).first()
+
+    query = """
+        query PetQuery {
+          pet {
+            name,
+            petKind
+            hairKind
+          }
+        }
+    """
+    expected = {"pet": {"name": "Garfield", "petKind": "CAT", "hairKind": "SHORT"}}
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query)
+    assert not result.errors
+    result = to_std_dicts(result.data)
+    assert result == expected
+
+
+def test_enum_as_argument(session):
+    add_test_data(session)
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    class Query(graphene.ObjectType):
+        pet = graphene.Field(
+            PetType,
+            kind=graphene.Argument(PetType.enum_for_field('pet_kind')))
+
+        def resolve_pet(self, info, kind=None):
+            query = session.query(Pet)
+            if kind:
+                query = query.filter(Pet.pet_kind == kind)
+            return query.first()
+
+    query = """
+        query PetQuery($kind: PetKind) {
+          pet(kind: $kind) {
+            name,
+            petKind
+            hairKind
+          }
+        }
+    """
+
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query, variables={"kind": "CAT"})
+    assert not result.errors
+    expected = {"pet": {"name": "Garfield", "petKind": "CAT", "hairKind": "SHORT"}}
+    assert result.data == expected
+    result = schema.execute(query, variables={"kind": "DOG"})
+    assert not result.errors
+    expected = {"pet": {"name": "Lassie", "petKind": "DOG", "hairKind": "LONG"}}
+    result = to_std_dicts(result.data)
+    assert result == expected
+
+
+def test_py_enum_as_argument(session):
+    add_test_data(session)
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    class Query(graphene.ObjectType):
+        pet = graphene.Field(
+            PetType,
+            kind=graphene.Argument(PetType._meta.fields["hair_kind"].type.of_type),
+        )
+
+        def resolve_pet(self, _info, kind=None):
+            query = session.query(Pet)
+            if kind:
+                # enum arguments are expected to be strings, not PyEnums
+                query = query.filter(Pet.hair_kind == HairKind(kind))
+            return query.first()
+
+    query = """
+        query PetQuery($kind: HairKind) {
+          pet(kind: $kind) {
+            name,
+            petKind
+            hairKind
+          }
+        }
+    """
+
+    schema = graphene.Schema(query=Query)
+    result = schema.execute(query, variables={"kind": "SHORT"})
+    assert not result.errors
+    expected = {"pet": {"name": "Garfield", "petKind": "CAT", "hairKind": "SHORT"}}
+    assert result.data == expected
+    result = schema.execute(query, variables={"kind": "LONG"})
+    assert not result.errors
+    expected = {"pet": {"name": "Lassie", "petKind": "DOG", "hairKind": "LONG"}}
+    result = to_std_dicts(result.data)
+    assert result == expected

--- a/graphene_sqlalchemy/tests/test_registry.py
+++ b/graphene_sqlalchemy/tests/test_registry.py
@@ -1,25 +1,15 @@
 import pytest
+from sqlalchemy.types import Enum as SQLAlchemyEnum
+
+from graphene import Enum as GrapheneEnum
 
 from ..registry import Registry
 from ..types import SQLAlchemyObjectType
+from ..utils import EnumValue
 from .models import Pet
 
 
-def test_register_incorrect_objecttype():
-    reg = Registry()
-
-    class Spam:
-        pass
-
-    with pytest.raises(AssertionError) as excinfo:
-        reg.register(Spam)
-
-    assert "Only classes of type SQLAlchemyObjectType can be registered" in str(
-        excinfo.value
-    )
-
-
-def test_register_objecttype():
+def test_register_object_type():
     reg = Registry()
 
     class PetType(SQLAlchemyObjectType):
@@ -27,7 +17,112 @@ def test_register_objecttype():
             model = Pet
             registry = reg
 
-    try:
-        reg.register(PetType)
-    except AssertionError:
-        pytest.fail("expected no AssertionError")
+    reg.register(PetType)
+    assert reg.get_type_for_model(Pet) is PetType
+
+
+def test_register_incorrect_object_type():
+    reg = Registry()
+
+    class Spam:
+        pass
+
+    re_err = "Expected SQLAlchemyObjectType, but got: .*Spam"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register(Spam)
+
+
+def test_register_orm_field():
+    reg = Registry()
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            registry = reg
+
+    reg.register_orm_field(PetType, "name", Pet.name)
+    assert reg.get_orm_field_for_graphene_field(PetType, "name") is Pet.name
+
+
+def test_register_orm_field_incorrect_types():
+    reg = Registry()
+
+    class Spam:
+        pass
+
+    re_err = "Expected SQLAlchemyObjectType, but got: .*Spam"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register_orm_field(Spam, "name", Pet.name)
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            registry = reg
+
+    re_err = "Expected a field name, but got: .*Spam"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register_orm_field(PetType, Spam, Pet.name)
+
+
+def test_register_enum():
+    reg = Registry()
+
+    sa_enum = SQLAlchemyEnum("cat", "dog")
+    graphene_enum = GrapheneEnum("PetKind", [("CAT", 1), ("DOG", 2)])
+
+    reg.register_enum(sa_enum, graphene_enum)
+    assert reg.get_graphene_enum_for_sa_enum(sa_enum) is graphene_enum
+
+
+def test_register_enum_incorrect_types():
+    reg = Registry()
+
+    sa_enum = SQLAlchemyEnum("cat", "dog")
+    graphene_enum = GrapheneEnum("PetKind", [("CAT", 1), ("DOG", 2)])
+
+    re_err = r"Expected Graphene Enum, but got: Enum\('cat', 'dog'\)"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register_enum(sa_enum, sa_enum)
+
+    re_err = r"Expected SQLAlchemyEnumType, but got: .*PetKind.*"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register_enum(graphene_enum, graphene_enum)
+
+
+def test_register_sort_enum():
+    reg = Registry()
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            registry = reg
+
+    sort_enum = GrapheneEnum(
+        "PetSort",
+        [("ID", EnumValue("id", Pet.id)), ("NAME", EnumValue("name", Pet.name))],
+    )
+
+    reg.register_sort_enum(PetType, sort_enum)
+    assert reg.get_sort_enum_for_object_type(PetType) is sort_enum
+
+
+def test_register_sort_enum_incorrect_types():
+    reg = Registry()
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            registry = reg
+
+    sort_enum = GrapheneEnum(
+        "PetSort",
+        [("ID", EnumValue("id", Pet.id)), ("NAME", EnumValue("name", Pet.name))],
+    )
+
+    re_err = r"Expected SQLAlchemyObjectType, but got: .*PetSort.*"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register_sort_enum(sort_enum, sort_enum)
+
+    re_err = r"Expected Graphene Enum, but got: .*PetType.*"
+    with pytest.raises(TypeError, match=re_err):
+        reg.register_sort_enum(PetType, PetType)

--- a/graphene_sqlalchemy/tests/test_schema.py
+++ b/graphene_sqlalchemy/tests/test_schema.py
@@ -35,6 +35,7 @@ def test_should_map_fields_correctly():
         "first_name",
         "last_name",
         "email",
+        "favorite_pet_kind",
         "pets",
         "articles",
         "favorite_article",

--- a/graphene_sqlalchemy/tests/test_sort_enums.py
+++ b/graphene_sqlalchemy/tests/test_sort_enums.py
@@ -1,0 +1,386 @@
+import pytest
+import sqlalchemy as sa
+
+from graphene import Argument, Enum, List, ObjectType, Schema
+from graphene.relay import Connection, Node
+
+from ..fields import SQLAlchemyConnectionField
+from ..types import SQLAlchemyObjectType
+from ..utils import to_type_name
+from .models import Base, HairKind, Pet
+from .test_query import to_std_dicts
+
+
+def add_pets(session):
+    pets = [
+        Pet(id=1, name="Lassie", pet_kind="dog", hair_kind=HairKind.LONG),
+        Pet(id=2, name="Barf", pet_kind="dog", hair_kind=HairKind.LONG),
+        Pet(id=3, name="Alf", pet_kind="cat", hair_kind=HairKind.LONG),
+    ]
+    session.add_all(pets)
+    session.commit()
+
+
+def test_sort_enum():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    sort_enum = PetType.sort_enum()
+    assert isinstance(sort_enum, type(Enum))
+    assert sort_enum._meta.name == "PetTypeSortEnum"
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "NAME_ASC",
+        "NAME_DESC",
+        "PET_KIND_ASC",
+        "PET_KIND_DESC",
+        "HAIR_KIND_ASC",
+        "HAIR_KIND_DESC",
+        "REPORTER_ID_ASC",
+        "REPORTER_ID_DESC",
+    ]
+    assert str(sort_enum.ID_ASC.value.value) == "pets.id ASC"
+    assert str(sort_enum.ID_DESC.value.value) == "pets.id DESC"
+    assert str(sort_enum.HAIR_KIND_ASC.value.value) == "pets.hair_kind ASC"
+    assert str(sort_enum.HAIR_KIND_DESC.value.value) == "pets.hair_kind DESC"
+
+
+def test_sort_enum_with_custom_name():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    sort_enum = PetType.sort_enum(name="CustomSortName")
+    assert isinstance(sort_enum, type(Enum))
+    assert sort_enum._meta.name == "CustomSortName"
+
+
+def test_sort_enum_cache():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    sort_enum = PetType.sort_enum()
+    sort_enum_2 = PetType.sort_enum()
+    assert sort_enum_2 is sort_enum
+    sort_enum_2 = PetType.sort_enum(name="PetTypeSortEnum")
+    assert sort_enum_2 is sort_enum
+    err_msg = "Sort enum for PetType has already been customized"
+    with pytest.raises(ValueError, match=err_msg):
+        PetType.sort_enum(name="CustomSortName")
+    with pytest.raises(ValueError, match=err_msg):
+        PetType.sort_enum(only_fields=["id"])
+    with pytest.raises(ValueError, match=err_msg):
+        PetType.sort_enum(only_indexed=True)
+    with pytest.raises(ValueError, match=err_msg):
+        PetType.sort_enum(get_symbol_name=lambda: "foo")
+
+
+def test_sort_enum_with_excluded_field_in_object_type():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            exclude_fields = ["reporter_id"]
+
+    sort_enum = PetType.sort_enum()
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "NAME_ASC",
+        "NAME_DESC",
+        "PET_KIND_ASC",
+        "PET_KIND_DESC",
+        "HAIR_KIND_ASC",
+        "HAIR_KIND_DESC",
+    ]
+
+
+def test_sort_enum_only_fields():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    sort_enum = PetType.sort_enum(only_fields=["id", "name"])
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "NAME_ASC",
+        "NAME_DESC",
+    ]
+
+
+def test_sort_argument():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    sort_arg = PetType.sort_argument()
+    assert isinstance(sort_arg, Argument)
+
+    assert isinstance(sort_arg.type, List)
+    sort_enum = sort_arg.type._of_type
+    assert isinstance(sort_enum, type(Enum))
+    assert sort_enum._meta.name == "PetTypeSortEnum"
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "NAME_ASC",
+        "NAME_DESC",
+        "PET_KIND_ASC",
+        "PET_KIND_DESC",
+        "HAIR_KIND_ASC",
+        "HAIR_KIND_DESC",
+        "REPORTER_ID_ASC",
+        "REPORTER_ID_DESC",
+    ]
+    assert str(sort_enum.ID_ASC.value.value) == "pets.id ASC"
+    assert str(sort_enum.ID_DESC.value.value) == "pets.id DESC"
+    assert str(sort_enum.HAIR_KIND_ASC.value.value) == "pets.hair_kind ASC"
+    assert str(sort_enum.HAIR_KIND_DESC.value.value) == "pets.hair_kind DESC"
+
+    assert sort_arg.default_value == ["ID_ASC"]
+    assert str(sort_enum.ID_ASC.value.value) == "pets.id ASC"
+
+
+def test_sort_argument_with_excluded_fields_in_object_type():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            exclude_fields = ["hair_kind", "reporter_id"]
+
+    sort_arg = PetType.sort_argument()
+    sort_enum = sort_arg.type._of_type
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "NAME_ASC",
+        "NAME_DESC",
+        "PET_KIND_ASC",
+        "PET_KIND_DESC",
+    ]
+    assert sort_arg.default_value == ["ID_ASC"]
+
+
+def test_sort_argument_only_fields():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            only_fields = ["id", "pet_kind"]
+
+    sort_arg = PetType.sort_argument()
+    sort_enum = sort_arg.type._of_type
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "PET_KIND_ASC",
+        "PET_KIND_DESC",
+    ]
+    assert sort_arg.default_value == ["ID_ASC"]
+
+
+def test_sort_argument_for_multi_column_pk():
+    class MultiPkTestModel(Base):
+        __tablename__ = "multi_pk_test_table"
+        foo = sa.Column(sa.Integer, primary_key=True)
+        bar = sa.Column(sa.Integer, primary_key=True)
+
+    class MultiPkTestType(SQLAlchemyObjectType):
+        class Meta:
+            model = MultiPkTestModel
+
+    sort_arg = MultiPkTestType.sort_argument()
+    assert sort_arg.default_value == ["FOO_ASC", "BAR_ASC"]
+
+
+def test_sort_argument_only_indexed():
+    class IndexedTestModel(Base):
+        __tablename__ = "indexed_test_table"
+        id = sa.Column(sa.Integer, primary_key=True)
+        foo = sa.Column(sa.Integer, index=False)
+        bar = sa.Column(sa.Integer, index=True)
+
+    class IndexedTestType(SQLAlchemyObjectType):
+        class Meta:
+            model = IndexedTestModel
+
+    sort_arg = IndexedTestType.sort_argument(only_indexed=True)
+    sort_enum = sort_arg.type._of_type
+    assert list(sort_enum._meta.enum.__members__) == [
+        "ID_ASC",
+        "ID_DESC",
+        "BAR_ASC",
+        "BAR_DESC",
+    ]
+    assert sort_arg.default_value == ["ID_ASC"]
+
+
+def test_sort_argument_with_custom_symbol_names():
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+
+    def get_symbol_name(column_name, sort_asc=True):
+        return to_type_name(column_name) + ("Up" if sort_asc else "Down")
+
+    sort_arg = PetType.sort_argument(get_symbol_name=get_symbol_name)
+    sort_enum = sort_arg.type._of_type
+    assert list(sort_enum._meta.enum.__members__) == [
+        "IdUp",
+        "IdDown",
+        "NameUp",
+        "NameDown",
+        "PetKindUp",
+        "PetKindDown",
+        "HairKindUp",
+        "HairKindDown",
+        "ReporterIdUp",
+        "ReporterIdDown",
+    ]
+    assert sort_arg.default_value == ["IdUp"]
+
+
+def test_sort_query(session):
+    add_pets(session)
+
+    class PetNode(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            interfaces = (Node,)
+
+    class PetConnection(Connection):
+        class Meta:
+            node = PetNode
+
+    class Query(ObjectType):
+        defaultSort = SQLAlchemyConnectionField(PetConnection)
+        nameSort = SQLAlchemyConnectionField(PetConnection)
+        multipleSort = SQLAlchemyConnectionField(PetConnection)
+        descSort = SQLAlchemyConnectionField(PetConnection)
+        singleColumnSort = SQLAlchemyConnectionField(
+            PetConnection, sort=Argument(PetNode.sort_enum())
+        )
+        noDefaultSort = SQLAlchemyConnectionField(
+            PetConnection, sort=PetNode.sort_argument(has_default=False)
+        )
+        noSort = SQLAlchemyConnectionField(PetConnection, sort=None)
+
+    query = """
+        query sortTest {
+            defaultSort {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+            nameSort(sort: NAME_ASC) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+            multipleSort(sort: [PET_KIND_ASC, NAME_DESC]) {
+                edges {
+                    node {
+                        name
+                        petKind
+                    }
+                }
+            }
+            descSort(sort: [NAME_DESC]) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+            singleColumnSort(sort: NAME_DESC) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+            noDefaultSort(sort: NAME_ASC) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+        }
+    """
+
+    def makeNodes(nodeList):
+        nodes = [{"node": item} for item in nodeList]
+        return {"edges": nodes}
+
+    expected = {
+        "defaultSort": makeNodes(
+            [{"name": "Lassie"}, {"name": "Barf"}, {"name": "Alf"}]
+        ),
+        "nameSort": makeNodes([{"name": "Alf"}, {"name": "Barf"}, {"name": "Lassie"}]),
+        "noDefaultSort": makeNodes(
+            [{"name": "Alf"}, {"name": "Barf"}, {"name": "Lassie"}]
+        ),
+        "multipleSort": makeNodes(
+            [
+                {"name": "Alf", "petKind": "CAT"},
+                {"name": "Lassie", "petKind": "DOG"},
+                {"name": "Barf", "petKind": "DOG"},
+            ]
+        ),
+        "descSort": makeNodes([{"name": "Lassie"}, {"name": "Barf"}, {"name": "Alf"}]),
+        "singleColumnSort": makeNodes(
+            [{"name": "Lassie"}, {"name": "Barf"}, {"name": "Alf"}]
+        ),
+    }  # yapf: disable
+
+    schema = Schema(query=Query)
+    result = schema.execute(query, context_value={"session": session})
+    assert not result.errors
+    result = to_std_dicts(result.data)
+    assert result == expected
+
+    queryError = """
+        query sortTest {
+            singleColumnSort(sort: [PET_KIND_ASC, NAME_DESC]) {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+        }
+    """
+    result = schema.execute(queryError, context_value={"session": session})
+    assert result.errors is not None
+    assert '"sort" has invalid value' in result.errors[0].message
+
+    queryNoSort = """
+        query sortTest {
+            noDefaultSort {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+            noSort {
+                edges {
+                    node {
+                        name
+                    }
+                }
+            }
+        }
+    """
+
+    result = schema.execute(queryNoSort, context_value={"session": session})
+    assert not result.errors
+    assert [node["node"]["name"] for node in result.data["noSort"]["edges"]] == [
+        node["node"]["name"] for node in result.data["noDefaultSort"]["edges"]
+    ]

--- a/graphene_sqlalchemy/tests/test_sort_enums.py
+++ b/graphene_sqlalchemy/tests/test_sort_enums.py
@@ -381,6 +381,9 @@ def test_sort_query(session):
 
     result = schema.execute(queryNoSort, context_value={"session": session})
     assert not result.errors
+    # TODO: SQLite usually returns the results ordered by primary key,
+    # so we cannot test this way whether sorting actually happens or not.
+    # Also, no sort order is guaranteed by SQLite if "no order" by is used.
     assert [node["node"]["name"] for node in result.data["noSort"]["edges"]] == [
         node["node"]["name"] for node in result.data["noDefaultSort"]["edges"]
     ]

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -57,6 +57,7 @@ def test_objecttype_registered():
         "first_name",
         "last_name",
         "email",
+        "favorite_pet_kind",
         "pets",
         "articles",
         "favorite_article",
@@ -124,6 +125,7 @@ def test_custom_objecttype_registered():
         "first_name",
         "last_name",
         "email",
+        "favorite_pet_kind",
         "pets",
         "articles",
         "favorite_article",
@@ -168,6 +170,7 @@ def test_objecttype_with_custom_options():
         "first_name",
         "last_name",
         "email",
+        "favorite_pet_kind",
         "pets",
         "articles",
         "favorite_article",
@@ -181,7 +184,7 @@ def test_promise_connection_resolver():
         class Meta:
             node = ReporterWithCustomOptions
 
-    def resolver(*args, **kwargs):
+    def resolver(_obj, _info):
         return Promise.resolve([])
 
     result = SQLAlchemyConnectionField.connection_resolver(

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,7 @@ max-line-length = 120
 [isort]
 known_graphene=graphene,graphql_relay,flask_graphql,graphql_server,sphinx_graphene_theme
 known_first_party=graphene_sqlalchemy
-known_third_party=flask,nameko,promise,py,pytest,setuptools,singledispatch,six,sqlalchemy,sqlalchemy_utils
+known_third_party=database,flask,models,nameko,promise,py,pytest,schema,setuptools,singledispatch,six,sqlalchemy,sqlalchemy_utils
 sections=FUTURE,STDLIB,THIRDPARTY,GRAPHENE,FIRSTPARTY,LOCALFOLDER
 no_lines_before=FIRSTPARTY
 


### PR DESCRIPTION
This is an implementation of what has been discussed in #208.

- create separate enum module
- create enums based on object type, not based on model
- convert enum type and value names
- provide more customization options
- split tests in different modules
- adapt flask_sqlalchemy example

When getting sort enums, you can now specify that you only want to sort certain columns or only the indexed columns.