### PR TITLE
Fix Example Apps

### DIFF
--- a/examples/flask_sqlalchemy/README.md
+++ b/examples/flask_sqlalchemy/README.md
@@ -9,7 +9,7 @@ Getting started
 ---------------
 
 First you'll need to get the source of the project. Do this by cloning the
-whole Graphene repository:
+whole Graphene-SQLAlchemy repository:
 
 ```bash
 # Get the example project code

--- a/examples/flask_sqlalchemy/requirements.txt
+++ b/examples/flask_sqlalchemy/requirements.txt
@@ -1,4 +1,2 @@
-graphene[sqlalchemy]
-SQLAlchemy==1.0.11
-Flask==0.12.4
-Flask-GraphQL==1.3.0
+-e ../../
+Flask-GraphQL

--- a/examples/nameko_sqlalchemy/README.md
+++ b/examples/nameko_sqlalchemy/README.md
@@ -14,7 +14,7 @@ Getting started
 ---------------
 
 First you'll need to get the source of the project. Do this by cloning the
-whole Graphene repository:
+whole Graphene-SQLAlchemy repository:
 
 ```bash
 # Get the example project code

--- a/examples/nameko_sqlalchemy/app.py
+++ b/examples/nameko_sqlalchemy/app.py
@@ -1,9 +1,9 @@
+from database import db_session, init_db
+from schema import schema
+
 from graphql_server import (HttpQueryError, default_format_error,
                             encode_execution_results, json_encode,
                             load_json_body, run_http_query)
-
-from .database import db_session, init_db
-from .schema import schema
 
 
 class App():

--- a/examples/nameko_sqlalchemy/models.py
+++ b/examples/nameko_sqlalchemy/models.py
@@ -1,7 +1,6 @@
+from database import Base
 from sqlalchemy import Column, DateTime, ForeignKey, Integer, String, func
 from sqlalchemy.orm import backref, relationship
-
-from .database import Base
 
 
 class Department(Base):

--- a/examples/nameko_sqlalchemy/requirements.txt
+++ b/examples/nameko_sqlalchemy/requirements.txt
@@ -1,4 +1,3 @@
-graphene[sqlalchemy]
-SQLAlchemy==1.0.11
-nameko
+-e ../../
 graphql-server-core
+nameko

--- a/examples/nameko_sqlalchemy/schema.py
+++ b/examples/nameko_sqlalchemy/schema.py
@@ -1,10 +1,10 @@
+from models import Department as DepartmentModel
+from models import Employee as EmployeeModel
+from models import Role as RoleModel
+
 import graphene
 from graphene import relay
 from graphene_sqlalchemy import SQLAlchemyConnectionField, SQLAlchemyObjectType
-
-from .models import Department as DepartmentModel
-from .models import Employee as EmployeeModel
-from .models import Role as RoleModel
 
 
 class Department(SQLAlchemyObjectType):

--- a/examples/nameko_sqlalchemy/service.py
+++ b/examples/nameko_sqlalchemy/service.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
+from app import App
 from nameko.web.handlers import http
-
-from .app import App
 
 
 class DepartmentService:

--- a/setup.cfg
+++ b/setup.cfg
@@ -6,11 +6,12 @@ exclude = setup.py,docs/*,examples/*,tests
 max-line-length = 120
 
 [isort]
+no_lines_before=FIRSTPARTY
 known_graphene=graphene,graphql_relay,flask_graphql,graphql_server,sphinx_graphene_theme
 known_first_party=graphene_sqlalchemy
-known_third_party=database,flask,models,nameko,promise,py,pytest,schema,setuptools,singledispatch,six,sqlalchemy,sqlalchemy_utils
+known_third_party=app,database,flask,models,nameko,promise,py,pytest,schema,setuptools,singledispatch,six,sqlalchemy,sqlalchemy_utils
 sections=FUTURE,STDLIB,THIRDPARTY,GRAPHENE,FIRSTPARTY,LOCALFOLDER
-no_lines_before=FIRSTPARTY
+skip_glob=examples/nameko_sqlalchemy
 
 [bdist_wheel]
 universal=1


### PR DESCRIPTION
- Update requirements.txt so they point at the local version of `graphene-sqlalchemy`
- Use absolute imports in `nameko_sqlalchemy` because `./run.sh` does not support absolute imports