### PR TITLE
Fix `createConnectionField` deprecation warnings

### DIFF
--- a/graphene_sqlalchemy/__init__.py
+++ b/graphene_sqlalchemy/__init__.py
@@ -2,7 +2,7 @@ from .types import SQLAlchemyObjectType
 from .fields import SQLAlchemyConnectionField
 from .utils import get_query, get_session
 
-__version__ = "2.2.0"
+__version__ = "2.2.1"
 
 __all__ = [
     "__version__",

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -1,4 +1,4 @@
-import logging
+import warnings
 from functools import partial
 
 from promise import Promise, is_thenable
@@ -9,8 +9,6 @@ from graphene.relay.connection import PageInfo
 from graphql_relay.connection.arrayconnection import connection_from_list_slice
 
 from .utils import get_query
-
-log = logging.getLogger()
 
 
 class UnsortedSQLAlchemyConnectionField(ConnectionField):
@@ -100,7 +98,7 @@ class SQLAlchemyConnectionField(UnsortedSQLAlchemyConnectionField):
 def default_connection_field_factory(relationship, registry, **field_kwargs):
     model = relationship.mapper.entity
     model_type = registry.get_type_for_model(model)
-    return createConnectionField(model_type, **field_kwargs)
+    return __connectionFactory(model_type, **field_kwargs)
 
 
 # TODO Remove in next major version
@@ -108,26 +106,29 @@ __connectionFactory = UnsortedSQLAlchemyConnectionField
 
 
 def createConnectionField(_type, **field_kwargs):
-    log.warning(
+    warnings.warn(
         'createConnectionField is deprecated and will be removed in the next '
-        'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.'
+        'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.',
+        DeprecationWarning,
     )
     return __connectionFactory(_type, **field_kwargs)
 
 
 def registerConnectionFieldFactory(factoryMethod):
-    log.warning(
+    warnings.warn(
         'registerConnectionFieldFactory is deprecated and will be removed in the next '
-        'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.'
+        'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.',
+        DeprecationWarning,
     )
     global __connectionFactory
     __connectionFactory = factoryMethod
 
 
 def unregisterConnectionFieldFactory():
-    log.warning(
+    warnings.warn(
         'registerConnectionFieldFactory is deprecated and will be removed in the next '
-        'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.'
+        'major version. Use SQLAlchemyObjectType.Meta.connection_field_factory instead.',
+        DeprecationWarning,
     )
     global __connectionFactory
     __connectionFactory = UnsortedSQLAlchemyConnectionField

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -364,33 +364,35 @@ def test_custom_connection_field_factory():
 
 
 def test_deprecated_registerConnectionFieldFactory():
-    registerConnectionFieldFactory(_TestSQLAlchemyConnectionField)
+    with pytest.warns(DeprecationWarning):
+        registerConnectionFieldFactory(_TestSQLAlchemyConnectionField)
 
-    class ReporterType(SQLAlchemyObjectType):
-        class Meta:
-            model = Reporter
-            interfaces = (Node,)
+        class ReporterType(SQLAlchemyObjectType):
+            class Meta:
+                model = Reporter
+                interfaces = (Node,)
 
-    class ArticleType(SQLAlchemyObjectType):
-        class Meta:
-            model = Article
-            interfaces = (Node,)
+        class ArticleType(SQLAlchemyObjectType):
+            class Meta:
+                model = Article
+                interfaces = (Node,)
 
-    assert isinstance(ReporterType._meta.fields['articles'].type(), _TestSQLAlchemyConnectionField)
+        assert isinstance(ReporterType._meta.fields['articles'].type(), _TestSQLAlchemyConnectionField)
 
 
 def test_deprecated_unregisterConnectionFieldFactory():
-    registerConnectionFieldFactory(_TestSQLAlchemyConnectionField)
-    unregisterConnectionFieldFactory()
+    with pytest.warns(DeprecationWarning):
+        registerConnectionFieldFactory(_TestSQLAlchemyConnectionField)
+        unregisterConnectionFieldFactory()
 
-    class ReporterType(SQLAlchemyObjectType):
-        class Meta:
-            model = Reporter
-            interfaces = (Node,)
+        class ReporterType(SQLAlchemyObjectType):
+            class Meta:
+                model = Reporter
+                interfaces = (Node,)
 
-    class ArticleType(SQLAlchemyObjectType):
-        class Meta:
-            model = Article
-            interfaces = (Node,)
+        class ArticleType(SQLAlchemyObjectType):
+            class Meta:
+                model = Article
+                interfaces = (Node,)
 
-    assert not isinstance(ReporterType._meta.fields['articles'].type(), _TestSQLAlchemyConnectionField)
+        assert not isinstance(ReporterType._meta.fields['articles'].type(), _TestSQLAlchemyConnectionField)

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -224,6 +224,19 @@ def test_sqlalchemy_override_fields():
     assert pets_field.type().description == 'Overridden'
 
 
+def test_invalid_model_attr():
+    err_msg = (
+        "Cannot map ORMField to a model attribute.\n"
+        "Field: 'ReporterType.first_name'"
+    )
+    with pytest.raises(ValueError, match=err_msg):
+        class ReporterType(SQLAlchemyObjectType):
+            class Meta:
+                model = Reporter
+
+            first_name = ORMField(model_attr='does_not_exist')
+
+
 def test_only_fields():
     class ReporterType(SQLAlchemyObjectType):
         class Meta:

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -7,7 +7,7 @@ from graphene import (Dynamic, Field, GlobalID, Int, List, Node, NonNull,
 
 from ..converter import convert_sqlalchemy_composite
 from ..fields import (SQLAlchemyConnectionField,
-                      UnsortedSQLAlchemyConnectionField,
+                      UnsortedSQLAlchemyConnectionField, createConnectionField,
                       registerConnectionFieldFactory,
                       unregisterConnectionFieldFactory)
 from ..types import ORMField, SQLAlchemyObjectType, SQLAlchemyObjectTypeOptions
@@ -396,3 +396,8 @@ def test_deprecated_unregisterConnectionFieldFactory():
                 interfaces = (Node,)
 
         assert not isinstance(ReporterType._meta.fields['articles'].type(), _TestSQLAlchemyConnectionField)
+
+
+def test_deprecated_createConnectionField():
+    with pytest.warns(DeprecationWarning):
+        createConnectionField(None)

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -133,7 +133,10 @@ def construct_fields(
     for orm_field_name, orm_field in custom_orm_fields_items:
         attr_name = orm_field.kwargs.get('model_attr', orm_field_name)
         if attr_name not in all_model_attrs:
-            raise Exception('Cannot map ORMField "{}" to SQLAlchemy model property'.format(orm_field_name))
+            raise ValueError((
+                "Cannot map ORMField to a model attribute.\n"
+                "Field: '{}.{}'"
+            ).format(obj_type.__name__, orm_field_name,))
         orm_field.kwargs['model_attr'] = attr_name
 
     # Merge automatic fields with custom ORM fields


### PR DESCRIPTION
- Fixes https://github.com/graphql-python/graphene-sqlalchemy/issues/228. These deprecation warnings were incorrectly raised by `default_connection_field_factory`.

- Releases fix as `2.2.1`