### PR TITLE
Removed assertions that were hiding exceptions

### DIFF
--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -21,7 +21,7 @@ from .enums import (enum_for_field, sort_argument_for_object_type,
                     sort_enum_for_object_type)
 from .fields import default_connection_field_factory
 from .registry import Registry, get_global_registry
-from .utils import get_query, is_mapped_class, is_mapped_instance
+from .utils import get_query
 
 
 class ORMField(OrderedType):
@@ -199,10 +199,6 @@ class SQLAlchemyObjectType(ObjectType):
         _meta=None,
         **options
     ):
-        assert is_mapped_class(model), (
-            "You need to pass a valid SQLAlchemy Model in " '{}.Meta, received "{}".'
-        ).format(cls.__name__, model)
-
         if not registry:
             registry = get_global_registry()
 
@@ -271,8 +267,6 @@ class SQLAlchemyObjectType(ObjectType):
     def is_type_of(cls, root, info):
         if isinstance(root, cls):
             return True
-        if not is_mapped_instance(root):
-            raise Exception(('Received incompatible instance "{}".').format(root))
         return isinstance(root, cls._meta.model)
 
     @classmethod

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -1,10 +1,6 @@
 import re
 import warnings
 
-from sqlalchemy.exc import ArgumentError
-from sqlalchemy.orm import class_mapper, object_mapper
-from sqlalchemy.orm.exc import UnmappedClassError, UnmappedInstanceError
-
 
 def get_session(context):
     return context.get("session")
@@ -21,24 +17,6 @@ def get_query(model, context):
             )
         query = session.query(model)
     return query
-
-
-def is_mapped_class(cls):
-    try:
-        class_mapper(cls)
-    except (ArgumentError, UnmappedClassError):
-        return False
-    else:
-        return True
-
-
-def is_mapped_instance(cls):
-    try:
-        object_mapper(cls)
-    except (ArgumentError, UnmappedInstanceError):
-        return False
-    else:
-        return True
 
 
 def to_type_name(name):


### PR DESCRIPTION
The two assertions that were testing the sqlalchemy classes and instances
worked by catching and silencing exceptions. This could cause debugging
problems like:

https://github.com/graphql-python/graphene-sqlalchemy/issues/121
https://github.com/graphql-python/graphene-sqlalchemy/issues/122

on the other hand without them, if someone uses unmapped class/model it
would be trivial to diagnose the problem. So I believe we would be
better off without them.

Fixes: #121