### PR TITLE
[Regression Fix] Call custom resolve functions if provided 

### DIFF
--- a/graphene_sqlalchemy/__init__.py
+++ b/graphene_sqlalchemy/__init__.py
@@ -2,7 +2,7 @@ from .types import SQLAlchemyObjectType
 from .fields import SQLAlchemyConnectionField
 from .utils import get_query, get_session
 
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 __all__ = [
     "__version__",

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -16,10 +16,6 @@ except ImportError:
     ChoiceType = JSONType = ScalarListType = TSVectorType = object
 
 
-def _get_attr_resolver(attr_name):
-    return lambda root, _info: getattr(root, attr_name, None)
-
-
 def get_column_doc(column):
     return getattr(column, "doc", None)
 
@@ -28,7 +24,7 @@ def is_column_nullable(column):
     return bool(getattr(column, "nullable", True))
 
 
-def convert_sqlalchemy_relationship(relationship_prop, registry, connection_field_factory, **field_kwargs):
+def convert_sqlalchemy_relationship(relationship_prop, registry, connection_field_factory, resolver, **field_kwargs):
     direction = relationship_prop.direction
     model = relationship_prop.mapper.entity
 
@@ -40,7 +36,7 @@ def convert_sqlalchemy_relationship(relationship_prop, registry, connection_fiel
         if direction == interfaces.MANYTOONE or not relationship_prop.uselist:
             return Field(
                 _type,
-                resolver=_get_attr_resolver(relationship_prop.key),
+                resolver=resolver,
                 **field_kwargs
             )
         elif direction in (interfaces.ONETOMANY, interfaces.MANYTOMANY):
@@ -55,18 +51,18 @@ def convert_sqlalchemy_relationship(relationship_prop, registry, connection_fiel
     return Dynamic(dynamic_type)
 
 
-def convert_sqlalchemy_hybrid_method(hybrid_prop, prop_name, **field_kwargs):
+def convert_sqlalchemy_hybrid_method(hybrid_prop, resolver, **field_kwargs):
     if 'type' not in field_kwargs:
         # TODO The default type should be dependent on the type of the property propety.
         field_kwargs['type'] = String
 
     return Field(
-        resolver=_get_attr_resolver(prop_name),
+        resolver=resolver,
         **field_kwargs
     )
 
 
-def convert_sqlalchemy_composite(composite_prop, registry):
+def convert_sqlalchemy_composite(composite_prop, registry, resolver):
     converter = registry.get_converter_for_composite(composite_prop.composite_class)
     if not converter:
         try:
@@ -100,14 +96,14 @@ def _register_composite_class(cls, registry=None):
 convert_sqlalchemy_composite.register = _register_composite_class
 
 
-def convert_sqlalchemy_column(column_prop, registry, **field_kwargs):
+def convert_sqlalchemy_column(column_prop, registry, resolver, **field_kwargs):
     column = column_prop.columns[0]
     field_kwargs.setdefault('type', convert_sqlalchemy_type(getattr(column, "type", None), column, registry))
     field_kwargs.setdefault('required', not is_column_nullable(column))
     field_kwargs.setdefault('description', get_column_doc(column))
 
     return Field(
-        resolver=_get_attr_resolver(column_prop.key),
+        resolver=resolver,
         **field_kwargs
     )
 

--- a/graphene_sqlalchemy/tests/conftest.py
+++ b/graphene_sqlalchemy/tests/conftest.py
@@ -2,6 +2,8 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+import graphene
+
 from ..converter import convert_sqlalchemy_composite
 from ..registry import reset_global_registry
 from .models import Base, CompositeFullName
@@ -17,7 +19,7 @@ def reset_registry():
     # Tests that explicitly depend on this behavior should re-register a converter
     @convert_sqlalchemy_composite.register(CompositeFullName)
     def convert_composite_class(composite, registry):
-        pass
+        return graphene.Field(graphene.Int)
 
 
 @pytest.yield_fixture(scope="function")

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -23,6 +23,10 @@ from ..types import SQLAlchemyObjectType
 from .models import Article, CompositeFullName, Pet, Reporter
 
 
+def mock_resolver():
+    pass
+
+
 def get_field(sqlalchemy_type, **column_kwargs):
     class Model(declarative_base()):
         __tablename__ = 'model'
@@ -30,7 +34,7 @@ def get_field(sqlalchemy_type, **column_kwargs):
         column = Column(sqlalchemy_type, doc="Custom Help Text", **column_kwargs)
 
     column_prop = inspect(Model).column_attrs['column']
-    return convert_sqlalchemy_column(column_prop, get_global_registry())
+    return convert_sqlalchemy_column(column_prop, get_global_registry(), mock_resolver)
 
 
 def get_field_from_column(column_):
@@ -40,7 +44,7 @@ def get_field_from_column(column_):
         column = column_
 
     column_prop = inspect(Model).column_attrs['column']
-    return convert_sqlalchemy_column(column_prop, get_global_registry())
+    return convert_sqlalchemy_column(column_prop, get_global_registry(), mock_resolver)
 
 
 def test_should_unknown_sqlalchemy_field_raise_exception():
@@ -162,7 +166,7 @@ def test_should_jsontype_convert_jsonstring():
 def test_should_manytomany_convert_connectionorlist():
     registry = Registry()
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, registry, default_connection_field_factory
+        Reporter.pets.property, registry, default_connection_field_factory, mock_resolver,
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert not dynamic_field.get_type()
@@ -174,7 +178,7 @@ def test_should_manytomany_convert_connectionorlist_list():
             model = Pet
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A._meta.registry, default_connection_field_factory
+        Reporter.pets.property, A._meta.registry, default_connection_field_factory, mock_resolver,
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -190,7 +194,7 @@ def test_should_manytomany_convert_connectionorlist_connection():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A._meta.registry, default_connection_field_factory
+        Reporter.pets.property, A._meta.registry, default_connection_field_factory, mock_resolver
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert isinstance(dynamic_field.get_type(), UnsortedSQLAlchemyConnectionField)
@@ -199,7 +203,10 @@ def test_should_manytomany_convert_connectionorlist_connection():
 def test_should_manytoone_convert_connectionorlist():
     registry = Registry()
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property, registry, default_connection_field_factory
+        Article.reporter.property,
+        registry,
+        default_connection_field_factory,
+        mock_resolver,
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert not dynamic_field.get_type()
@@ -211,7 +218,10 @@ def test_should_manytoone_convert_connectionorlist_list():
             model = Reporter
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property, A._meta.registry, default_connection_field_factory
+        Article.reporter.property,
+        A._meta.registry,
+        default_connection_field_factory,
+        mock_resolver,
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -226,7 +236,10 @@ def test_should_manytoone_convert_connectionorlist_connection():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property, A._meta.registry, default_connection_field_factory
+        Article.reporter.property,
+        A._meta.registry,
+        default_connection_field_factory,
+        mock_resolver,
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -244,6 +257,7 @@ def test_should_onetoone_convert_field():
         Reporter.favorite_article.property,
         A._meta.registry,
         default_connection_field_factory,
+        mock_resolver,
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -310,6 +324,7 @@ def test_should_composite_convert():
     field = convert_sqlalchemy_composite(
         composite(CompositeClass, (Column(types.Unicode(50)), Column(types.Unicode(50))), doc="Custom Help Text"),
         registry,
+        mock_resolver,
     )
     assert isinstance(field, graphene.String)
 
@@ -325,4 +340,5 @@ def test_should_unknown_sqlalchemy_composite_raise_exception():
         convert_sqlalchemy_composite(
             composite(CompositeFullName, (Column(types.Unicode(50)), Column(types.Unicode(50)))),
             Registry(),
+            mock_resolver,
         )

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -3,7 +3,7 @@ import pytest
 import six  # noqa F401
 
 from graphene import (Dynamic, Field, GlobalID, Int, List, Node, NonNull,
-                      ObjectType, String)
+                      ObjectType, Schema, String)
 
 from ..converter import convert_sqlalchemy_composite
 from ..fields import (SQLAlchemyConnectionField,
@@ -264,6 +264,7 @@ def test_exclude_fields():
         "column_prop",
         "email",
         "favorite_pet_kind",
+        "composite_prop",
         "hybrid_prop",
         "pets",
         "articles",
@@ -293,6 +294,73 @@ def test_sqlalchemy_redefine_field():
     assert first_name_field.type == Int
 
 
+def test_resolvers(session):
+    """Test that the correct resolver functions are called"""
+
+    class ReporterMixin(object):
+        def resolve_id(root, _info):
+            return 'ID'
+
+    class ReporterType(ReporterMixin, SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+
+        email = ORMField()
+        email_v2 = ORMField(model_attr='email')
+        favorite_pet_kind = Field(String)
+        favorite_pet_kind_v2 = Field(String)
+
+        def resolve_last_name(root, _info):
+            return root.last_name.upper()
+
+        def resolve_email_v2(root, _info):
+            return root.email + '_V2'
+
+        def resolve_favorite_pet_kind_v2(root, _info):
+            return str(root.favorite_pet_kind) + '_V2'
+
+    class Query(ObjectType):
+        reporter = Field(ReporterType)
+
+        def resolve_reporter(self, _info):
+            return session.query(Reporter).first()
+
+    reporter = Reporter(first_name='first_name', last_name='last_name', email='email', favorite_pet_kind='cat')
+    session.add(reporter)
+    session.commit()
+
+    schema = Schema(query=Query)
+    result = schema.execute("""
+        query {
+            reporter {
+                id
+                firstName
+                lastName
+                email
+                emailV2
+                favoritePetKind
+                favoritePetKindV2
+            }
+        }
+    """)
+
+    assert not result.errors
+    # Custom resolver on a base class
+    assert result.data['reporter']['id'] == 'ID'
+    # Default field + default resolver
+    assert result.data['reporter']['firstName'] == 'first_name'
+    # Default field + custom resolver
+    assert result.data['reporter']['lastName'] == 'LAST_NAME'
+    # ORMField + default resolver
+    assert result.data['reporter']['email'] == 'email'
+    # ORMField + custom resolver
+    assert result.data['reporter']['emailV2'] == 'email_V2'
+    # Field + default resolver
+    assert result.data['reporter']['favoritePetKind'] == 'cat'
+    # Field + custom resolver
+    assert result.data['reporter']['favoritePetKindV2'] == 'cat_V2'
+
+
 # Test Custom SQLAlchemyObjectType Implementation
 
 def test_custom_objecttype_registered():
@@ -306,7 +374,7 @@ def test_custom_objecttype_registered():
 
     assert issubclass(CustomReporterType, ObjectType)
     assert CustomReporterType._meta.model == Reporter
-    assert len(CustomReporterType._meta.fields) == 10
+    assert len(CustomReporterType._meta.fields) == 11
 
 
 # Test Custom SQLAlchemyObjectType with Custom Options


### PR DESCRIPTION
Fixes issue https://github.com/graphql-python/graphene-sqlalchemy/issues/234. The regression was introduced in [2.2.1](https://github.com/graphql-python/graphene-sqlalchemy/commit/9a0f7400957c5b5f5f8e952db2502ef1f79fac1f). 

Custom `resolve_<field_name>` functions were no longer call for fields auto-generated by `SQLAlchemyObjectType`. The issue was caused by a soon-to-be-documented feature that allows users to rename auto-generated fields (aka `ORMField.model_attr`).
