### PR TITLE
Make relationship arrays nonnull and required

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import interfaces
 
 from graphene import (ID, Boolean, Dynamic, Enum, Field, Float, Int, List,
-                      String, NonNull)
+                      NonNull, String)
 from graphene.types.json import JSONString
 
 from .enums import enum_for_sa_enum

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -6,7 +6,7 @@ from sqlalchemy.dialects import postgresql
 from sqlalchemy.orm import interfaces
 
 from graphene import (ID, Boolean, Dynamic, Enum, Field, Float, Int, List,
-                      String)
+                      String, NonNull)
 from graphene.types.json import JSONString
 
 from .enums import enum_for_sa_enum
@@ -46,7 +46,8 @@ def convert_sqlalchemy_relationship(relationship_prop, registry, connection_fiel
                 # TODO Add a way to override connection_field_factory
                 return connection_field_factory(relationship_prop, registry, **field_kwargs)
             return Field(
-                List(_type),
+                List(NonNull(_type)),
+                required=True,
                 **field_kwargs
             )
 

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -209,8 +209,12 @@ def test_should_manytomany_convert_connectionorlist_list():
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
     assert isinstance(graphene_type, graphene.Field)
-    assert isinstance(graphene_type.type, graphene.List)
-    assert graphene_type.type.of_type == A
+    assert isinstance(graphene_type.type, graphene.NonNull)
+    list_type = graphene_type.type.type.of_type
+    assert isinstance(list_type, graphene.List)
+    list_element_type = list_type.of_type
+    assert isinstance(list_element_type, graphene.NonNull)
+    assert list_element_type.of_type == A
 
 
 def test_should_manytomany_convert_connectionorlist_connection():

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -210,7 +210,7 @@ def test_should_manytomany_convert_connectionorlist_list():
     graphene_type = dynamic_field.get_type()
     assert isinstance(graphene_type, graphene.Field)
     assert isinstance(graphene_type.type, graphene.NonNull)
-    list_type = graphene_type.type.type.of_type
+    list_type = graphene_type.type.of_type
     assert isinstance(list_type, graphene.List)
     list_element_type = list_type.of_type
     assert isinstance(list_element_type, graphene.NonNull)

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -219,8 +219,12 @@ def test_sqlalchemy_override_fields():
 
     pets_field = ReporterType._meta.fields['pets']
     assert isinstance(pets_field, Dynamic)
-    assert isinstance(pets_field.type().type, List)
-    assert pets_field.type().type.of_type == PetType
+    assert isinstance(pets_field.type().type, NonNull)
+    list_type = pets_field.type().type.of_type
+    assert isinstance(list_type, List)
+    list_element_type = list_type.of_type
+    assert isinstance(list_element_type, NonNull)
+    assert list_element_type.of_type == PetType
     assert pets_field.type().description == 'Overridden'
 
 


### PR DESCRIPTION
See https://github.com/graphql-python/graphene-sqlalchemy/issues/251

It will be harder (maybe impossible?) to make the Child -> Parent relationship Non-null, because there is not a single way to determine whether or not it's non-null.

In this example class
```
Child(db.Model):
    __tablename__ = "child"
    id = db.Column(Integer, primary_key=True)

    parent_id = db.Column(Integer, ForeignKey("parent.id"), nullable=False)
    parent = db.relationship("Parent", back_populates="children")
```

We can know for sure that parent is non-null because the parent_id column is nullable=False, however if it used `primaryjoin=xxx` or `foreign_keys=[key1,key2]`, We would have to introspect those and check all the possible columns for nullability.

However, for the O2M or the M2M cases, SQLAlchemy returns a collection of objects: https://docs.sqlalchemy.org/en/13/orm/collections.html#customizing-collection-access

(It looks like you can also actually return a dictionary mapping instead of a colleciton, however graphene-sqlalchemy currently doesn't support this use case anyway since it hardcodes List)