### PR TITLE
Fix N+1 problem for one-to-one and many-to-one relationships

### DIFF
--- a/graphene_sqlalchemy/tests/conftest.py
+++ b/graphene_sqlalchemy/tests/conftest.py
@@ -1,6 +1,6 @@
 import pytest
 from sqlalchemy import create_engine
-from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.orm import sessionmaker
 
 import graphene
 
@@ -23,19 +23,17 @@ def reset_registry():
 
 
 @pytest.yield_fixture(scope="function")
-def session():
-    db = create_engine(test_db_url)
-    connection = db.engine.connect()
-    transaction = connection.begin()
-    Base.metadata.create_all(connection)
+def session_factory():
+    engine = create_engine(test_db_url)
+    Base.metadata.create_all(engine)
 
-    # options = dict(bind=connection, binds={})
-    session_factory = sessionmaker(bind=connection)
-    session = scoped_session(session_factory)
+    yield sessionmaker(bind=engine)
 
-    yield session
+    # SQLite in-memory db is deleted when its connection is closed.
+    # https://www.sqlite.org/inmemorydb.html
+    engine.dispose()
 
-    # Finalize test here
-    transaction.rollback()
-    connection.close()
-    session.remove()
+
+@pytest.fixture(scope="function")
+def session(session_factory):
+    return session_factory()

--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -1,0 +1,203 @@
+import contextlib
+import logging
+
+import graphene
+
+from ..types import SQLAlchemyObjectType
+from .models import Article, Reporter
+from .utils import to_std_dicts
+
+
+class MockLoggingHandler(logging.Handler):
+    """Intercept and store log messages in a list."""
+    def __init__(self, *args, **kwargs):
+        self.messages = []
+        logging.Handler.__init__(self, *args, **kwargs)
+
+    def emit(self, record):
+        self.messages.append(record.getMessage())
+
+
+@contextlib.contextmanager
+def mock_sqlalchemy_logging_handler():
+    logging.basicConfig()
+    sql_logger = logging.getLogger('sqlalchemy.engine')
+    previous_level = sql_logger.level
+
+    sql_logger.setLevel(logging.INFO)
+    mock_logging_handler = MockLoggingHandler()
+    mock_logging_handler.setLevel(logging.INFO)
+    sql_logger.addHandler(mock_logging_handler)
+
+    yield mock_logging_handler
+
+    sql_logger.setLevel(previous_level)
+
+
+def make_fixture(session):
+    reporter_1 = Reporter(
+      first_name='Reporter_1',
+    )
+    session.add(reporter_1)
+    reporter_2 = Reporter(
+      first_name='Reporter_2',
+    )
+    session.add(reporter_2)
+
+    article_1 = Article(headline='Article_1')
+    article_1.reporter = reporter_1
+    session.add(article_1)
+
+    article_2 = Article(headline='Article_2')
+    article_2.reporter = reporter_2
+    session.add(article_2)
+
+    session.commit()
+    session.close()
+
+
+def get_schema(session):
+    class ReporterType(SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+
+    class ArticleType(SQLAlchemyObjectType):
+        class Meta:
+            model = Article
+
+    class Query(graphene.ObjectType):
+        articles = graphene.Field(graphene.List(ArticleType))
+        reporters = graphene.Field(graphene.List(ReporterType))
+
+        def resolve_articles(self, _info):
+            return session.query(Article).all()
+
+        def resolve_reporters(self, _info):
+            return session.query(Reporter).all()
+
+    return graphene.Schema(query=Query)
+
+
+def test_many_to_one(session_factory):
+    session = session_factory()
+    make_fixture(session)
+    schema = get_schema(session)
+
+    with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
+        # Starts new session to fully reset the engine / connection logging level
+        session = session_factory()
+        result = schema.execute("""
+          query {
+            articles {
+              headline
+              reporter {
+                firstName
+              }
+            }
+          }
+        """, context_value={"session": session})
+        messages = sqlalchemy_logging_handler.messages
+
+    assert len(messages) == 5
+    assert messages == [
+      'BEGIN (implicit)',
+
+      'SELECT articles.id AS articles_id, '
+      'articles.headline AS articles_headline, '
+      'articles.pub_date AS articles_pub_date, '
+      'articles.reporter_id AS articles_reporter_id \n'
+      'FROM articles',
+      '()',
+
+      'SELECT reporters.id AS reporters_id, '
+      '(SELECT CAST(count(reporters.id) AS INTEGER) AS anon_2 \nFROM reporters) AS anon_1, '
+      'reporters.first_name AS reporters_first_name, '
+      'reporters.last_name AS reporters_last_name, '
+      'reporters.email AS reporters_email, '
+      'reporters.favorite_pet_kind AS reporters_favorite_pet_kind \n'
+      'FROM reporters \n'
+      'WHERE reporters.id IN (?, ?)',
+      '(1, 2)',
+    ]
+
+    assert not result.errors
+    result = to_std_dicts(result.data)
+    assert result == {
+      "articles": [
+        {
+          "headline": "Article_1",
+          "reporter": {
+            "firstName": "Reporter_1",
+          },
+        },
+        {
+          "headline": "Article_2",
+          "reporter": {
+            "firstName": "Reporter_2",
+          },
+        },
+      ],
+    }
+
+
+def test_one_to_one(session_factory):
+    session = session_factory()
+    make_fixture(session)
+    schema = get_schema(session)
+
+    with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
+        # Starts new session to fully reset the engine / connection logging level
+        session = session_factory()
+        result = schema.execute("""
+          query {
+            reporters {
+              firstName
+              favoriteArticle {
+                headline
+              }
+            }
+          }
+        """, context_value={"session": session})
+        messages = sqlalchemy_logging_handler.messages
+
+    assert len(messages) == 5
+    assert messages == [
+      'BEGIN (implicit)',
+
+      'SELECT (SELECT CAST(count(reporters.id) AS INTEGER) AS anon_2 \nFROM reporters) AS anon_1, '
+      'reporters.id AS reporters_id, '
+      'reporters.first_name AS reporters_first_name, '
+      'reporters.last_name AS reporters_last_name, '
+      'reporters.email AS reporters_email, '
+      'reporters.favorite_pet_kind AS reporters_favorite_pet_kind \n'
+      'FROM reporters',
+      '()',
+
+      'SELECT articles.reporter_id AS articles_reporter_id, '
+      'articles.id AS articles_id, '
+      'articles.headline AS articles_headline, '
+      'articles.pub_date AS articles_pub_date \n'
+      'FROM articles \n'
+      'WHERE articles.reporter_id IN (?, ?) '
+      'ORDER BY articles.reporter_id',
+      '(1, 2)'
+    ]
+
+    assert not result.errors
+    result = to_std_dicts(result.data)
+    assert result == {
+      "reporters": [
+        {
+          "firstName": "Reporter_1",
+          "favoriteArticle": {
+            "headline": "Article_1",
+          },
+        },
+        {
+          "firstName": "Reporter_2",
+          "favoriteArticle": {
+            "headline": "Article_2",
+          },
+        },
+      ],
+    }

--- a/graphene_sqlalchemy/tests/test_query.py
+++ b/graphene_sqlalchemy/tests/test_query.py
@@ -5,16 +5,7 @@ from ..converter import convert_sqlalchemy_composite
 from ..fields import SQLAlchemyConnectionField
 from ..types import ORMField, SQLAlchemyObjectType
 from .models import Article, CompositeFullName, Editor, HairKind, Pet, Reporter
-
-
-def to_std_dicts(value):
-    """Convert nested ordered dicts to normal dicts for better comparison."""
-    if isinstance(value, dict):
-        return {k: to_std_dicts(v) for k, v in value.items()}
-    elif isinstance(value, list):
-        return [to_std_dicts(v) for v in value]
-    else:
-        return value
+from .utils import to_std_dicts
 
 
 def add_test_data(session):

--- a/graphene_sqlalchemy/tests/utils.py
+++ b/graphene_sqlalchemy/tests/utils.py
@@ -1,0 +1,8 @@
+def to_std_dicts(value):
+    """Convert nested ordered dicts to normal dicts for better comparison."""
+    if isinstance(value, dict):
+        return {k: to_std_dicts(v) for k, v in value.items()}
+    elif isinstance(value, list):
+        return [to_std_dicts(v) for v in value]
+    else:
+        return value

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -8,7 +8,6 @@ from sqlalchemy.orm import (ColumnProperty, CompositeProperty,
 from sqlalchemy.orm.exc import NoResultFound
 from sqlalchemy.orm.query import QueryContext
 from sqlalchemy.orm.strategies import SelectInLoader
-from sqlalchemy.orm.util import PathRegistry
 
 from graphene import Field
 from graphene.relay import Connection, Node
@@ -265,9 +264,6 @@ def _get_relationship_resolver(obj_type, relationship_prop, model_attr):
 
             loader = SelectInLoader(relationship_prop, (('lazy', 'selectin'),))
 
-            # The path is a fixed single token in this case
-            path = PathRegistry.root + parent_mapper._path_registry
-
             # Should the boolean be set to False? Does it matter for our purposes?
             states = [(sqlalchemy.inspect(parent), True) for parent in parents]
 
@@ -276,7 +272,7 @@ def _get_relationship_resolver(obj_type, relationship_prop, model_attr):
 
             loader._load_for_path(
                 query_context,
-                path,
+                parent_mapper._path_registry,
                 states,
                 None,
                 child_mapper,

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -245,12 +245,8 @@ def _get_relationship_resolver(obj_type, relationship_prop, model_attr):
             when callling `all()`, we skip the first `SELECT` statement
             and jump right before the `selectin` loader is called.
             To accomplish this, we have to construct objects that are
-            normally built in the first part of the query and then
-            call then invoke the `selectin` post loader.
-
-            For this reason, if you're trying to understand the steps below,
-            it's easier to start at the bottom (ie `post_load.invoke`) and
-            go backward.
+            normally built in the first part of the query in order
+            to call directly `SelectInLoader._load_for_path`.
             """
             session = Session.object_session(parents[0])
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,7 +9,7 @@ max-line-length = 120
 no_lines_before=FIRSTPARTY
 known_graphene=graphene,graphql_relay,flask_graphql,graphql_server,sphinx_graphene_theme
 known_first_party=graphene_sqlalchemy
-known_third_party=app,database,flask,mock,models,nameko,promise,pytest,schema,setuptools,singledispatch,six,sqlalchemy,sqlalchemy_utils
+known_third_party=app,database,flask,mock,models,nameko,pkg_resources,promise,pytest,schema,setuptools,singledispatch,six,sqlalchemy,sqlalchemy_utils
 sections=FUTURE,STDLIB,THIRDPARTY,GRAPHENE,FIRSTPARTY,LOCALFOLDER
 skip_glob=examples/nameko_sqlalchemy
 

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ requirements = [
     "graphene>=2.1.3,<3",
     "promise>=2.1",
     # Tests fail with 1.0.19
-    "SQLAlchemy>=1.1,<2",
+    "SQLAlchemy>=1.2,<2",
     "six>=1.10.0,<2",
     "singledispatch>=3.4.0.3,<4",
 ]

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ with open("graphene_sqlalchemy/__init__.py", "rb") as f:
 requirements = [
     # To keep things simple, we only support newer versions of Graphene
     "graphene>=2.1.3,<3",
+    "promise>=2.1",
     # Tests fail with 1.0.19
     "SQLAlchemy>=1.1,<2",
     "six>=1.10.0,<2",


### PR DESCRIPTION
Hi everyone,

This PR fixes the N+1 problem for `one-to-one` and `many-to-one` relationships. If we think this approach makes sense, I'll send a separate PR to address `one-to-many` and `many-to-many` relationships.

**Design goals**
- Be completely seamless to end-users. You should not need to modify your `SQLAlchemy` models or your `SQLAlchemyObjectType` models to benefit from this.

- Work with any `SQLAlchemy` relationships, including ones that have complex `primaryjoin` and `secondaryjoin` conditions.

- Avoid generating one large SQL query using nested `JOIN` in the resolver of the root field of the query. For non-trivial queries, the joined SQL statement is complex with hard-to-predict performances. See SQLAlchemy's [comparison of `selectin` with `joined` loading](https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#select-in-loading) for more context. 

- Fully work in schemas that include non-`SQLAlchemyObjectType` Graphene types. This batching optimization should compose well with other types, including those that use `Dataloader` under the hood.

- Avoid building SQL queries manually. It's non-trivial to generate correct SQL statements that support complex joins and composite primary keys across a variety of DBs. We should lean as much as possible on SQLAlchemy to do the heavy lifting.

**Non-goals**
- Only select the columns / fields that are being queried. This will be addressed in a separate PR.

- Caching records so we don't fetch the same record twice from the DB. This is tricky to get right. We can revisit this later if there is a need.  

**Solution**

The idea here is to have `SQLAlchemyObjectType` automatically generate batch resolvers for relationships. The resolvers use [`Dataloader`](https://docs.graphene-python.org/en/latest/execution/dataloader/) to collect all the similar `relationship` property accesses. From there, we ask `SQLAlchemy` to load all the relationships of those parents as one SQL query.

`SQLAlchemy` does not have a public API to do this but we can piggyback on some internal APIs of the [`selectin`](https://docs.sqlalchemy.org/en/13/orm/loading_relationships.html#select-in-loading) eager loading strategy. It's a bit hacky but I think it's better than re-implementing and maintaining a big chunk of the [`selectin` loader logic](https://github.com/sqlalchemy/sqlalchemy/blob/master/lib/sqlalchemy/orm/strategies.py#L2294-L2481) ourselves. You can find more details about this approach in the docstring of the batch loader. Hopefully we can get some feedback from the `SQLAlchemy` maintainers (cc @zzzeek). 

If we decide to move forward with this PR, I'll make sure to add more test cases so we can catch regressions in the event the internal `SQLALchemy` APIs we rely on change.   

Cheers,
J