### PR TITLE
Fix N+1 problem for one-to-many and many-to-many relationships

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,7 @@ var/
 *.egg-info/
 .installed.cfg
 *.egg
+.python-version
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -47,6 +48,7 @@ nosetests.xml
 coverage.xml
 *,cover
 .pytest_cache/
+.benchmarks/
 
 # Translations
 *.mo

--- a/graphene_sqlalchemy/__init__.py
+++ b/graphene_sqlalchemy/__init__.py
@@ -2,7 +2,7 @@ from .types import SQLAlchemyObjectType
 from .fields import SQLAlchemyConnectionField
 from .utils import get_query, get_session
 
-__version__ = "2.2.2"
+__version__ = "2.3.0.dev0"
 
 __all__ = [
     "__version__",

--- a/graphene_sqlalchemy/batching.py
+++ b/graphene_sqlalchemy/batching.py
@@ -1,0 +1,69 @@
+import sqlalchemy
+from promise import dataloader, promise
+from sqlalchemy.orm import Session, strategies
+from sqlalchemy.orm.query import QueryContext
+
+
+def get_batch_resolver(relationship_prop):
+    class RelationshipLoader(dataloader.DataLoader):
+        cache = False
+
+        def batch_load_fn(self, parents):  # pylint: disable=method-hidden
+            """
+            Batch loads the relationships of all the parents as one SQL statement.
+
+            There is no way to do this out-of-the-box with SQLAlchemy but
+            we can piggyback on some internal APIs of the `selectin`
+            eager loading strategy. It's a bit hacky but it's preferable
+            than re-implementing and maintainnig a big chunk of the `selectin`
+            loader logic ourselves.
+
+            The approach here is to build a regular query that
+            selects the parent and `selectin` load the relationship.
+            But instead of having the query emits 2 `SELECT` statements
+            when callling `all()`, we skip the first `SELECT` statement
+            and jump right before the `selectin` loader is called.
+            To accomplish this, we have to construct objects that are
+            normally built in the first part of the query in order
+            to call directly `SelectInLoader._load_for_path`.
+
+            TODO Move this logic to a util in the SQLAlchemy repo as per
+              SQLAlchemy's main maitainer suggestion.
+              See https://git.io/JewQ7
+            """
+            child_mapper = relationship_prop.mapper
+            parent_mapper = relationship_prop.parent
+            session = Session.object_session(parents[0])
+
+            # These issues are very unlikely to happen in practice...
+            for parent in parents:
+                # assert parent.__mapper__ is parent_mapper
+                # All instances must share the same session
+                assert session is Session.object_session(parent)
+                # The behavior of `selectin` is undefined if the parent is dirty
+                assert parent not in session.dirty
+
+            loader = strategies.SelectInLoader(relationship_prop, (('lazy', 'selectin'),))
+
+            # Should the boolean be set to False? Does it matter for our purposes?
+            states = [(sqlalchemy.inspect(parent), True) for parent in parents]
+
+            # For our purposes, the query_context will only used to get the session
+            query_context = QueryContext(session.query(parent_mapper.entity))
+
+            loader._load_for_path(
+                query_context,
+                parent_mapper._path_registry,
+                states,
+                None,
+                child_mapper,
+            )
+
+            return promise.Promise.resolve([getattr(parent, relationship_prop.key) for parent in parents])
+
+    loader = RelationshipLoader()
+
+    def resolve(root, info, **args):
+        return loader.load(root)
+
+    return resolve

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -61,7 +61,7 @@ class Reporter(Base):
     last_name = Column(String(30), doc="Last name")
     email = Column(String(), doc="Email")
     favorite_pet_kind = Column(PetKind)
-    pets = relationship("Pet", secondary=association_table, backref="reporters")
+    pets = relationship("Pet", secondary=association_table, backref="reporters", order_by="Pet.id")
     articles = relationship("Article", backref="reporter")
     favorite_article = relationship("Article", uselist=False)
 

--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -5,9 +5,11 @@ import pkg_resources
 import pytest
 
 import graphene
+from graphene import relay
 
+from ..fields import BatchSQLAlchemyConnectionField
 from ..types import SQLAlchemyObjectType
-from .models import Article, Reporter
+from .models import Article, HairKind, Pet, Reporter
 from .utils import to_std_dicts
 
 
@@ -37,7 +39,49 @@ def mock_sqlalchemy_logging_handler():
     sql_logger.setLevel(previous_level)
 
 
-def make_fixture(session):
+def get_schema():
+    class ReporterType(SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (relay.Node,)
+            connection_field_factory = BatchSQLAlchemyConnectionField.from_relationship
+
+    class ArticleType(SQLAlchemyObjectType):
+        class Meta:
+            model = Article
+            interfaces = (relay.Node,)
+            connection_field_factory = BatchSQLAlchemyConnectionField.from_relationship
+
+    class PetType(SQLAlchemyObjectType):
+        class Meta:
+            model = Pet
+            interfaces = (relay.Node,)
+            connection_field_factory = BatchSQLAlchemyConnectionField.from_relationship
+
+    class Query(graphene.ObjectType):
+        articles = graphene.Field(graphene.List(ArticleType))
+        reporters = graphene.Field(graphene.List(ReporterType))
+
+        def resolve_articles(self, info):
+            return info.context.get('session').query(Article).all()
+
+        def resolve_reporters(self, info):
+            return info.context.get('session').query(Reporter).all()
+
+    return graphene.Schema(query=Query)
+
+
+def is_sqlalchemy_version_less_than(version_string):
+    return pkg_resources.get_distribution('SQLAlchemy').parsed_version < pkg_resources.parse_version(version_string)
+
+
+if is_sqlalchemy_version_less_than('1.2'):
+    pytest.skip('SQL batching only works for SQLAlchemy 1.2+', allow_module_level=True)
+
+
+def test_many_to_one(session_factory):
+    session = session_factory()
+
     reporter_1 = Reporter(
       first_name='Reporter_1',
     )
@@ -58,41 +102,7 @@ def make_fixture(session):
     session.commit()
     session.close()
 
-
-def get_schema(session):
-    class ReporterType(SQLAlchemyObjectType):
-        class Meta:
-            model = Reporter
-
-    class ArticleType(SQLAlchemyObjectType):
-        class Meta:
-            model = Article
-
-    class Query(graphene.ObjectType):
-        articles = graphene.Field(graphene.List(ArticleType))
-        reporters = graphene.Field(graphene.List(ReporterType))
-
-        def resolve_articles(self, _info):
-            return session.query(Article).all()
-
-        def resolve_reporters(self, _info):
-            return session.query(Reporter).all()
-
-    return graphene.Schema(query=Query)
-
-
-def is_sqlalchemy_version_less_than(version_string):
-    return pkg_resources.get_distribution('SQLAlchemy').parsed_version < pkg_resources.parse_version(version_string)
-
-
-if is_sqlalchemy_version_less_than('1.2'):
-    pytest.skip('SQL batching only works for SQLAlchemy 1.2+', allow_module_level=True)
-
-
-def test_many_to_one(session_factory):
-    session = session_factory()
-    make_fixture(session)
-    schema = get_schema(session)
+    schema = get_schema()
 
     with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
         # Starts new session to fully reset the engine / connection logging level
@@ -160,8 +170,28 @@ def test_many_to_one(session_factory):
 
 def test_one_to_one(session_factory):
     session = session_factory()
-    make_fixture(session)
-    schema = get_schema(session)
+
+    reporter_1 = Reporter(
+      first_name='Reporter_1',
+    )
+    session.add(reporter_1)
+    reporter_2 = Reporter(
+      first_name='Reporter_2',
+    )
+    session.add(reporter_2)
+
+    article_1 = Article(headline='Article_1')
+    article_1.reporter = reporter_1
+    session.add(article_1)
+
+    article_2 = Article(headline='Article_2')
+    article_2.reporter = reporter_2
+    session.add(article_2)
+
+    session.commit()
+    session.close()
+
+    schema = get_schema()
 
     with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
         # Starts new session to fully reset the engine / connection logging level
@@ -222,6 +252,260 @@ def test_one_to_one(session_factory):
           "firstName": "Reporter_2",
           "favoriteArticle": {
             "headline": "Article_2",
+          },
+        },
+      ],
+    }
+
+
+def test_one_to_many(session_factory):
+    session = session_factory()
+
+    reporter_1 = Reporter(
+      first_name='Reporter_1',
+    )
+    session.add(reporter_1)
+    reporter_2 = Reporter(
+      first_name='Reporter_2',
+    )
+    session.add(reporter_2)
+
+    article_1 = Article(headline='Article_1')
+    article_1.reporter = reporter_1
+    session.add(article_1)
+
+    article_2 = Article(headline='Article_2')
+    article_2.reporter = reporter_1
+    session.add(article_2)
+
+    article_3 = Article(headline='Article_3')
+    article_3.reporter = reporter_2
+    session.add(article_3)
+
+    article_4 = Article(headline='Article_4')
+    article_4.reporter = reporter_2
+    session.add(article_4)
+
+    session.commit()
+    session.close()
+
+    schema = get_schema()
+
+    with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
+        # Starts new session to fully reset the engine / connection logging level
+        session = session_factory()
+        result = schema.execute("""
+          query {
+            reporters {
+              firstName
+              articles(first: 2) {
+                edges {
+                  node {
+                    headline
+                  }
+                }
+              }
+            }
+          }
+        """, context_value={"session": session})
+        messages = sqlalchemy_logging_handler.messages
+
+    assert len(messages) == 5
+
+    if is_sqlalchemy_version_less_than('1.3'):
+        # The batched SQL statement generated is different in 1.2.x
+        # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
+        # See https://git.io/JewQu
+        return
+
+    assert messages == [
+      'BEGIN (implicit)',
+
+      'SELECT (SELECT CAST(count(reporters.id) AS INTEGER) AS anon_2 \nFROM reporters) AS anon_1, '
+      'reporters.id AS reporters_id, '
+      'reporters.first_name AS reporters_first_name, '
+      'reporters.last_name AS reporters_last_name, '
+      'reporters.email AS reporters_email, '
+      'reporters.favorite_pet_kind AS reporters_favorite_pet_kind \n'
+      'FROM reporters',
+      '()',
+
+      'SELECT articles.reporter_id AS articles_reporter_id, '
+      'articles.id AS articles_id, '
+      'articles.headline AS articles_headline, '
+      'articles.pub_date AS articles_pub_date \n'
+      'FROM articles \n'
+      'WHERE articles.reporter_id IN (?, ?) '
+      'ORDER BY articles.reporter_id',
+      '(1, 2)'
+    ]
+
+    assert not result.errors
+    result = to_std_dicts(result.data)
+    assert result == {
+      "reporters": [
+        {
+          "firstName": "Reporter_1",
+          "articles": {
+            "edges": [
+              {
+                "node": {
+                  "headline": "Article_1",
+                },
+              },
+              {
+                "node": {
+                  "headline": "Article_2",
+                },
+              },
+            ],
+          },
+        },
+        {
+          "firstName": "Reporter_2",
+          "articles": {
+            "edges": [
+              {
+                "node": {
+                  "headline": "Article_3",
+                },
+              },
+              {
+                "node": {
+                  "headline": "Article_4",
+                },
+              },
+            ],
+          },
+        },
+      ],
+    }
+
+
+def test_many_to_many(session_factory):
+    session = session_factory()
+
+    reporter_1 = Reporter(
+      first_name='Reporter_1',
+    )
+    session.add(reporter_1)
+    reporter_2 = Reporter(
+      first_name='Reporter_2',
+    )
+    session.add(reporter_2)
+
+    pet_1 = Pet(name='Pet_1', pet_kind='cat', hair_kind=HairKind.LONG)
+    session.add(pet_1)
+
+    pet_2 = Pet(name='Pet_2', pet_kind='cat', hair_kind=HairKind.LONG)
+    session.add(pet_2)
+
+    reporter_1.pets.append(pet_1)
+    reporter_1.pets.append(pet_2)
+
+    pet_3 = Pet(name='Pet_3', pet_kind='cat', hair_kind=HairKind.LONG)
+    session.add(pet_3)
+
+    pet_4 = Pet(name='Pet_4', pet_kind='cat', hair_kind=HairKind.LONG)
+    session.add(pet_4)
+
+    reporter_2.pets.append(pet_3)
+    reporter_2.pets.append(pet_4)
+
+    session.commit()
+    session.close()
+
+    schema = get_schema()
+
+    with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
+        # Starts new session to fully reset the engine / connection logging level
+        session = session_factory()
+        result = schema.execute("""
+          query {
+            reporters {
+              firstName
+              pets(first: 2) {
+                edges {
+                  node {
+                    name
+                  }
+                }
+              }
+            }
+          }
+        """, context_value={"session": session})
+        messages = sqlalchemy_logging_handler.messages
+
+    assert len(messages) == 5
+
+    if is_sqlalchemy_version_less_than('1.3'):
+        # The batched SQL statement generated is different in 1.2.x
+        # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
+        # See https://git.io/JewQu
+        return
+
+    assert messages == [
+      'BEGIN (implicit)',
+
+      'SELECT (SELECT CAST(count(reporters.id) AS INTEGER) AS anon_2 \nFROM reporters) AS anon_1, '
+      'reporters.id AS reporters_id, '
+      'reporters.first_name AS reporters_first_name, '
+      'reporters.last_name AS reporters_last_name, '
+      'reporters.email AS reporters_email, '
+      'reporters.favorite_pet_kind AS reporters_favorite_pet_kind \n'
+      'FROM reporters',
+      '()',
+
+      'SELECT reporters_1.id AS reporters_1_id, '
+      'pets.id AS pets_id, '
+      'pets.name AS pets_name, '
+      'pets.pet_kind AS pets_pet_kind, '
+      'pets.hair_kind AS pets_hair_kind, '
+      'pets.reporter_id AS pets_reporter_id \n'
+      'FROM reporters AS reporters_1 '
+      'JOIN association AS association_1 ON reporters_1.id = association_1.reporter_id '
+      'JOIN pets ON pets.id = association_1.pet_id \n'
+      'WHERE reporters_1.id IN (?, ?) '
+      'ORDER BY reporters_1.id, pets.id',
+      '(1, 2)'
+    ]
+
+    assert not result.errors
+    result = to_std_dicts(result.data)
+    assert result == {
+      "reporters": [
+        {
+          "firstName": "Reporter_1",
+          "pets": {
+            "edges": [
+              {
+                "node": {
+                  "name": "Pet_1",
+                },
+              },
+              {
+                "node": {
+                  "name": "Pet_2",
+                },
+              },
+            ],
+          },
+        },
+        {
+          "firstName": "Reporter_2",
+          "pets": {
+            "edges": [
+              {
+                "node": {
+                  "name": "Pet_3",
+                },
+              },
+              {
+                "node": {
+                  "name": "Pet_4",
+                },
+              },
+            ],
           },
         },
       ],

--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -125,6 +125,8 @@ def test_many_to_one(session_factory):
         # The batched SQL statement generated is different in 1.2.x
         # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
         # See https://git.io/JewQu
+        sql_statements = [message for message in messages if 'SELECT' in message and 'JOIN reporters' in message]
+        assert len(sql_statements) == 1
         return
 
     assert messages == [
@@ -214,6 +216,8 @@ def test_one_to_one(session_factory):
         # The batched SQL statement generated is different in 1.2.x
         # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
         # See https://git.io/JewQu
+        sql_statements = [message for message in messages if 'SELECT' in message and 'JOIN articles' in message]
+        assert len(sql_statements) == 1
         return
 
     assert messages == [
@@ -316,6 +320,8 @@ def test_one_to_many(session_factory):
         # The batched SQL statement generated is different in 1.2.x
         # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
         # See https://git.io/JewQu
+        sql_statements = [message for message in messages if 'SELECT' in message and 'JOIN articles' in message]
+        assert len(sql_statements) == 1
         return
 
     assert messages == [
@@ -442,6 +448,8 @@ def test_many_to_many(session_factory):
         # The batched SQL statement generated is different in 1.2.x
         # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
         # See https://git.io/JewQu
+        sql_statements = [message for message in messages if 'SELECT' in message and 'JOIN pets' in message]
+        assert len(sql_statements) == 1
         return
 
     assert messages == [


### PR DESCRIPTION
This re-uses all the batching logic implemented in https://github.com/graphql-python/graphene-sqlalchemy/pull/253.

This optimization batches what used to be multiple SQL statements into a single SQL statement. While this this an improvement over the previous behavior, there is still some room for more optimizations: 
- We currently fetch all the children records of the relationship (vs just the ones being requested). Unfortunately, it's not possible to batch pagination with most SQL backends (see Join-Monster [overview of the problem](https://join-monster.readthedocs.io/en/latest/pagination/)). This can gets quite complex so I think we should punt on that for now.
- We currently fetch all the fields of the associated table (vs just the ones being queried). This should be relatively straightforward to implement (though there are some interesting edge cases) so I'm planning to address this soon.

For now, I decided to put this into a separate `BatchSQLAlchemyConnectionField` because the `...ConnectionField` classes need to be refactored a bit in order to allow people to easily opt-out of the batching behavior if need be (via the `ORMField` mechanism). I'll be addressing this in a follow up PR soon. For now, you'll have to enable the optimization via the `SQLAlchemyObjectType.Meta.connection_field_factory` (see `test_batching.py`). 

Cheers








