### PR TITLE
Add `batching` params 

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -3,19 +3,26 @@ from enum import EnumMeta
 from singledispatch import singledispatch
 from sqlalchemy import types
 from sqlalchemy.dialects import postgresql
-from sqlalchemy.orm import interfaces
+from sqlalchemy.orm import interfaces, strategies
 
 from graphene import (ID, Boolean, Dynamic, Enum, Field, Float, Int, List,
                       String)
 from graphene.types.json import JSONString
 
+from .batching import get_batch_resolver
 from .enums import enum_for_sa_enum
+from .fields import (BatchSQLAlchemyConnectionField,
+                     default_connection_field_factory)
 from .registry import get_global_registry
+from .resolvers import get_attr_resolver, get_custom_resolver
 
 try:
     from sqlalchemy_utils import ChoiceType, JSONType, ScalarListType, TSVectorType
 except ImportError:
     ChoiceType = JSONType = ScalarListType = TSVectorType = object
+
+
+is_selectin_available = getattr(strategies, 'SelectInLoader', None)
 
 
 def get_column_doc(column):
@@ -26,29 +33,46 @@ def is_column_nullable(column):
     return bool(getattr(column, "nullable", True))
 
 
-def convert_sqlalchemy_relationship(relationship_prop, registry, connection_field_factory, resolver, **field_kwargs):
-    direction = relationship_prop.direction
-    model = relationship_prop.mapper.entity
-
+def convert_sqlalchemy_relationship(relationship_prop, obj_type, connection_field_factory, batching,
+                                    attr_name, orm_field_name, **field_kwargs):
+    """
+    :param sqlalchemy.RelationshipProperty relationship_prop:
+    :param Registry registry:
+    :type function|None connection_field_factory:
+    :type bool batching:
+    :param SQLAlchemyObjectType obj_type:
+    :param str orm_field_name:
+    :rtype: Dynamic
+    """
     def dynamic_type():
-        _type = registry.get_type_for_model(model)
+        direction = relationship_prop.direction
+        model = relationship_prop.mapper.entity
+        type_ = obj_type._meta.registry.get_type_for_model(model)
 
-        if not _type:
+        batching_ = batching if is_selectin_available else False
+        connection_field_factory_ = connection_field_factory
+
+        if not type_:
             return None
+
         if direction == interfaces.MANYTOONE or not relationship_prop.uselist:
-            return Field(
-                _type,
-                resolver=resolver,
-                **field_kwargs
-            )
-        elif direction in (interfaces.ONETOMANY, interfaces.MANYTOMANY):
-            if _type._meta.connection:
-                # TODO Add a way to override connection_field_factory
-                return connection_field_factory(relationship_prop, registry, **field_kwargs)
-            return Field(
-                List(_type),
-                **field_kwargs
-            )
+            resolver = get_custom_resolver(obj_type, orm_field_name)
+            if resolver is None:
+                resolver = get_batch_resolver(relationship_prop) if batching_ else \
+                    get_attr_resolver(obj_type, relationship_prop.key)
+
+            return Field(type_, resolver=resolver, **field_kwargs)
+
+        if direction in (interfaces.ONETOMANY, interfaces.MANYTOMANY):
+            if not type_._meta.connection:
+                return Field(List(type_), **field_kwargs)
+
+            if connection_field_factory_ is None:
+                connection_field_factory_ = BatchSQLAlchemyConnectionField.from_relationship if batching_ else \
+                    default_connection_field_factory
+
+            # TODO Allow override of connection_field_factory and resolver via ORMField
+            return connection_field_factory_(relationship_prop, obj_type._meta.registry, **field_kwargs)
 
     return Dynamic(dynamic_type)
 

--- a/graphene_sqlalchemy/resolvers.py
+++ b/graphene_sqlalchemy/resolvers.py
@@ -1,0 +1,26 @@
+from graphene.utils.get_unbound_function import get_unbound_function
+
+
+def get_custom_resolver(obj_type, orm_field_name):
+    """
+    Since `graphene` will call `resolve_<field_name>` on a field only if it
+    does not have a `resolver`, we need to re-implement that logic here so
+    users are able to override the default resolvers that we provide.
+    """
+    resolver = getattr(obj_type, 'resolve_{}'.format(orm_field_name), None)
+    if resolver:
+        return get_unbound_function(resolver)
+
+    return None
+
+
+def get_attr_resolver(obj_type, model_attr):
+    """
+    In order to support field renaming via `ORMField.model_attr`,
+    we need to define resolver functions for each field.
+
+    :param SQLAlchemyObjectType obj_type:
+    :param str model_attr: the name of the SQLAlchemy attribute
+    :rtype: Callable
+    """
+    return lambda root, _info: getattr(root, model_attr, None)

--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -637,7 +637,13 @@ def test_connection_factory_field_overrides_batching_is_false(session_factory):
         """, context_value={"session": session})
         messages = sqlalchemy_logging_handler.messages
 
-    select_statements = [message for message in messages if 'SELECT' in message and 'FROM articles' in message]
+    if is_sqlalchemy_version_less_than('1.3'):
+        # The batched SQL statement generated is different in 1.2.x
+        # SQLAlchemy 1.3+ optimizes out a JOIN statement in `selectin`
+        # See https://git.io/JewQu
+        select_statements = [message for message in messages if 'SELECT' in message and 'JOIN articles' in message]
+    else:
+        select_statements = [message for message in messages if 'SELECT' in message and 'FROM articles' in message]
     assert len(select_statements) == 1
 
 

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -195,7 +195,7 @@ def test_should_manytomany_convert_connectionorlist():
             model = Article
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Reporter.pets.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert not dynamic_field.get_type()
@@ -207,7 +207,7 @@ def test_should_manytomany_convert_connectionorlist_list():
             model = Pet
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Reporter.pets.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -223,7 +223,7 @@ def test_should_manytomany_convert_connectionorlist_connection():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Reporter.pets.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert isinstance(dynamic_field.get_type(), UnsortedSQLAlchemyConnectionField)
@@ -235,7 +235,7 @@ def test_should_manytoone_convert_connectionorlist():
             model = Article
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Reporter.pets.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert not dynamic_field.get_type()
@@ -247,7 +247,7 @@ def test_should_manytoone_convert_connectionorlist_list():
             model = Reporter
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Article.reporter.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -262,7 +262,7 @@ def test_should_manytoone_convert_connectionorlist_connection():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Article.reporter.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -277,7 +277,7 @@ def test_should_onetoone_convert_field():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.favorite_article.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
+        Reporter.favorite_article.property, A, default_connection_field_factory, True, 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -190,9 +190,12 @@ def test_should_jsontype_convert_jsonstring():
 
 
 def test_should_manytomany_convert_connectionorlist():
-    registry = Registry()
+    class A(SQLAlchemyObjectType):
+        class Meta:
+            model = Article
+
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, registry, default_connection_field_factory, mock_resolver,
+        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert not dynamic_field.get_type()
@@ -204,7 +207,7 @@ def test_should_manytomany_convert_connectionorlist_list():
             model = Pet
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A._meta.registry, default_connection_field_factory, mock_resolver,
+        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -220,19 +223,19 @@ def test_should_manytomany_convert_connectionorlist_connection():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.pets.property, A._meta.registry, default_connection_field_factory, mock_resolver
+        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert isinstance(dynamic_field.get_type(), UnsortedSQLAlchemyConnectionField)
 
 
 def test_should_manytoone_convert_connectionorlist():
-    registry = Registry()
+    class A(SQLAlchemyObjectType):
+        class Meta:
+            model = Article
+
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property,
-        registry,
-        default_connection_field_factory,
-        mock_resolver,
+        Reporter.pets.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     assert not dynamic_field.get_type()
@@ -244,10 +247,7 @@ def test_should_manytoone_convert_connectionorlist_list():
             model = Reporter
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property,
-        A._meta.registry,
-        default_connection_field_factory,
-        mock_resolver,
+        Article.reporter.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -262,10 +262,7 @@ def test_should_manytoone_convert_connectionorlist_connection():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Article.reporter.property,
-        A._meta.registry,
-        default_connection_field_factory,
-        mock_resolver,
+        Article.reporter.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()
@@ -280,10 +277,7 @@ def test_should_onetoone_convert_field():
             interfaces = (Node,)
 
     dynamic_field = convert_sqlalchemy_relationship(
-        Reporter.favorite_article.property,
-        A._meta.registry,
-        default_connection_field_factory,
-        mock_resolver,
+        Reporter.favorite_article.property, A, default_connection_field_factory, True, 'attr_name', 'orm_field_name',
     )
     assert isinstance(dynamic_field, graphene.Dynamic)
     graphene_type = dynamic_field.get_type()

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -162,8 +162,7 @@ def construct_fields(
         elif isinstance(attr, RelationshipProperty):
             batching_ = orm_field.kwargs.pop('batching', batching)
             field = convert_sqlalchemy_relationship(
-                attr, obj_type, connection_field_factory, batching_, attr_name,
-                orm_field_name, **orm_field.kwargs)
+                attr, obj_type, connection_field_factory, batching_, orm_field_name, **orm_field.kwargs)
         elif isinstance(attr, CompositeProperty):
             if attr_name != orm_field_name or orm_field.kwargs:
                 # TODO Add a way to override composite property fields


### PR DESCRIPTION
Add parameters to toggle `batching` on or off. This can be configured at 2 levels:
- we can configure all the fields of a type at once via `SQLAlchemyObjectType.meta.batching` 
- or we can specify it for a specific field via `ORMfield.batching`. This trumps `SQLAlchemyObjectType.meta.batching`.


