### PR TITLE
Add support for Non-Null SQLAlchemyConnectionField

### DIFF
--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -233,8 +233,7 @@ def test_one_to_one(session_factory):
       'articles.headline AS articles_headline, '
       'articles.pub_date AS articles_pub_date \n'
       'FROM articles \n'
-      'WHERE articles.reporter_id IN (?, ?) '
-      'ORDER BY articles.reporter_id',
+      'WHERE articles.reporter_id IN (?, ?)',
       '(1, 2)'
     ]
 
@@ -337,8 +336,7 @@ def test_one_to_many(session_factory):
       'articles.headline AS articles_headline, '
       'articles.pub_date AS articles_pub_date \n'
       'FROM articles \n'
-      'WHERE articles.reporter_id IN (?, ?) '
-      'ORDER BY articles.reporter_id',
+      'WHERE articles.reporter_id IN (?, ?)',
       '(1, 2)'
     ]
 
@@ -470,7 +468,7 @@ def test_many_to_many(session_factory):
       'JOIN association AS association_1 ON reporters_1.id = association_1.reporter_id '
       'JOIN pets ON pets.id = association_1.pet_id \n'
       'WHERE reporters_1.id IN (?, ?) '
-      'ORDER BY reporters_1.id, pets.id',
+      'ORDER BY pets.id',
       '(1, 2)'
     ]
 

--- a/graphene_sqlalchemy/tests/test_fields.py
+++ b/graphene_sqlalchemy/tests/test_fields.py
@@ -1,7 +1,7 @@
 import pytest
 from promise import Promise
 
-from graphene import ObjectType
+from graphene import NonNull, ObjectType
 from graphene.relay import Connection, Node
 
 from ..fields import (SQLAlchemyConnectionField,
@@ -24,6 +24,20 @@ class Editor(SQLAlchemyObjectType):
 ##
 # SQLAlchemyConnectionField
 ##
+
+
+def test_nonnull_sqlalachemy_connection():
+    field = SQLAlchemyConnectionField(NonNull(Pet.connection))
+    assert isinstance(field.type, NonNull)
+    assert issubclass(field.type.of_type, Connection)
+    assert field.type.of_type._meta.node is Pet
+
+
+def test_required_sqlalachemy_connection():
+    field = SQLAlchemyConnectionField(Pet.connection, required=True)
+    assert isinstance(field.type, NonNull)
+    assert issubclass(field.type.of_type, Connection)
+    assert field.type.of_type._meta.node is Pet
 
 
 def test_promise_connection_resolver():


### PR DESCRIPTION
`SQLAlchemyConnectionField` doesn't handle Non-Null wrapped types. Currently, passing `required=True` to `SQLAlchemyConnectionField` raises an exception.