### PR TITLE
Add class property `connection` to `SQLAlchemyObjectType`

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -42,7 +42,7 @@ def convert_sqlalchemy_relationship(relationship_prop, registry, connection_fiel
                 **field_kwargs
             )
         elif direction in (interfaces.ONETOMANY, interfaces.MANYTOMANY):
-            if _type._meta.connection:
+            if _type.connection:
                 # TODO Add a way to override connection_field_factory
                 return connection_field_factory(relationship_prop, registry, **field_kwargs)
             return Field(

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -24,10 +24,10 @@ class UnsortedSQLAlchemyConnectionField(ConnectionField):
         assert issubclass(_type, SQLAlchemyObjectType), (
             "SQLALchemyConnectionField only accepts SQLAlchemyObjectType types, not {}"
         ).format(_type.__name__)
-        assert _type._meta.connection, "The type {} doesn't have a connection".format(
+        assert _type.connection, "The type {} doesn't have a connection".format(
             _type.__name__
         )
-        return _type._meta.connection
+        return _type.connection
 
     @property
     def model(self):
@@ -115,7 +115,7 @@ class BatchSQLAlchemyConnectionField(UnsortedSQLAlchemyConnectionField):
     def from_relationship(cls, relationship, registry, **field_kwargs):
         model = relationship.mapper.entity
         model_type = registry.get_type_for_model(model)
-        return cls(model_type._meta.connection, resolver=get_batch_resolver(relationship), **field_kwargs)
+        return cls(model_type.connection, resolver=get_batch_resolver(relationship), **field_kwargs)
 
 
 def default_connection_field_factory(relationship, registry, **field_kwargs):

--- a/graphene_sqlalchemy/tests/test_fields.py
+++ b/graphene_sqlalchemy/tests/test_fields.py
@@ -31,7 +31,7 @@ def test_promise_connection_resolver():
         return Promise.resolve([])
 
     result = UnsortedSQLAlchemyConnectionField.connection_resolver(
-        resolver, Pet._meta.connection, Pet, None, None
+        resolver, Pet.connection, Pet, None, None
     )
     assert isinstance(result, Promise)
 
@@ -51,18 +51,18 @@ def test_type_assert_object_has_connection():
 
 
 def test_sort_added_by_default():
-    field = SQLAlchemyConnectionField(Pet._meta.connection)
+    field = SQLAlchemyConnectionField(Pet.connection)
     assert "sort" in field.args
     assert field.args["sort"] == Pet.sort_argument()
 
 
 def test_sort_can_be_removed():
-    field = SQLAlchemyConnectionField(Pet._meta.connection, sort=None)
+    field = SQLAlchemyConnectionField(Pet.connection, sort=None)
     assert "sort" not in field.args
 
 
 def test_custom_sort():
-    field = SQLAlchemyConnectionField(Pet._meta.connection, sort=Editor.sort_argument())
+    field = SQLAlchemyConnectionField(Pet.connection, sort=Editor.sort_argument())
     assert field.args["sort"] == Editor.sort_argument()
 
 

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -4,6 +4,7 @@ import six  # noqa F401
 
 from graphene import (Dynamic, Field, GlobalID, Int, List, Node, NonNull,
                       ObjectType, Schema, String)
+from graphene.relay import Connection
 
 from ..converter import convert_sqlalchemy_composite
 from ..fields import (SQLAlchemyConnectionField,
@@ -44,6 +45,15 @@ def test_sqlalchemy_node(session):
     info = mock.Mock(context={'session': session})
     reporter_node = ReporterType.get_node(info, reporter.id)
     assert reporter == reporter_node
+
+
+def test_connection():
+    class ReporterType(SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+            interfaces = (Node,)
+
+    assert issubclass(ReporterType.connection, Connection)
 
 
 def test_sqlalchemy_default_fields():

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -325,6 +325,8 @@ class SQLAlchemyObjectType(ObjectType):
         _meta.connection = connection
         _meta.id = id or "id"
 
+        cls.connection = connection  # Public way to get the connection
+
         super(SQLAlchemyObjectType, cls).__init_subclass_with_meta__(
             _meta=_meta, interfaces=interfaces, **options
         )


### PR DESCRIPTION
Currently to get the default `connection` of a `SQLAlchemyObjectType`, you have to go through `_meta`. For example, `PetType._meta.connection`. This adds a public way to get it.

It's going to allow us to instantiate a `SQLAlchemyConnectionField` with the connection type (vs the model type). Instantiating a `ConnectionField` with the node type has been deprecated since [graphene 2.0](https://github.com/graphql-python/graphene/blob/v2.0.0/UPGRADE-v2.0.md#node-connections).  We will deprecate it too soon for consistency.