### PR TITLE
[documentation] Fix Connection patterns

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -13,20 +13,10 @@ Search all Models with Union
             interfaces = (relay.Node,)
 
 
-    class BookConnection(relay.Connection):
-        class Meta:
-            node = Book
-
-
     class Author(SQLAlchemyObjectType):
         class Meta:
             model = AuthorModel
             interfaces = (relay.Node,)
-
-
-    class AuthorConnection(relay.Connection):
-        class Meta:
-            node = Author
 
 
     class SearchResult(graphene.Union):
@@ -39,8 +29,8 @@ Search all Models with Union
         search = graphene.List(SearchResult, q=graphene.String())  # List field for search results
 
         # Normal Fields
-        all_books = SQLAlchemyConnectionField(BookConnection)
-        all_authors = SQLAlchemyConnectionField(AuthorConnection)
+        all_books = SQLAlchemyConnectionField(Book.connection)
+        all_authors = SQLAlchemyConnectionField(Author.connection)
 
         def resolve_search(self, info, **args):
             q = args.get("q")  # Search query

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -50,13 +50,8 @@ Given the model
             model = Pet
 
 
-    class PetConnection(Connection):
-        class Meta:
-            node = PetNode
-
-
     class Query(ObjectType):
-        allPets = SQLAlchemyConnectionField(PetConnection)
+        allPets = SQLAlchemyConnectionField(PetNode.connection)
 
 some of the allowed queries are
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -102,28 +102,18 @@ Create ``flask_sqlalchemy/schema.py`` and type the following:
             interfaces = (relay.Node, )
 
 
-    class DepartmentConnection(relay.Connection):
-        class Meta:
-            node = Department
-
-
     class Employee(SQLAlchemyObjectType):
         class Meta:
             model = EmployeeModel
             interfaces = (relay.Node, )
 
 
-    class EmployeeConnection(relay.Connection):
-        class Meta:
-            node = Employee
-
-
     class Query(graphene.ObjectType):
         node = relay.Node.Field()
         # Allows sorting over multiple columns, by default over the primary key
-        all_employees = SQLAlchemyConnectionField(EmployeeConnection)
+        all_employees = SQLAlchemyConnectionField(Employee.connection)
         # Disable sorting over this field
-        all_departments = SQLAlchemyConnectionField(DepartmentConnection, sort=None)
+        all_departments = SQLAlchemyConnectionField(Department.connection, sort=None)
 
     schema = graphene.Schema(query=Query)
 

--- a/examples/flask_sqlalchemy/schema.py
+++ b/examples/flask_sqlalchemy/schema.py
@@ -29,11 +29,11 @@ class Query(graphene.ObjectType):
     node = relay.Node.Field()
     # Allow only single column sorting
     all_employees = SQLAlchemyConnectionField(
-        Employee, sort=Employee.sort_argument())
+        Employee.connection, sort=Employee.sort_argument())
     # Allows sorting over multiple columns, by default over the primary key
-    all_roles = SQLAlchemyConnectionField(Role)
+    all_roles = SQLAlchemyConnectionField(Role.connection)
     # Disable sorting over this field
-    all_departments = SQLAlchemyConnectionField(Department, sort=None)
+    all_departments = SQLAlchemyConnectionField(Department.connection, sort=None)
 
 
-schema = graphene.Schema(query=Query, types=[Department, Employee, Role])
+schema = graphene.Schema(query=Query)

--- a/examples/nameko_sqlalchemy/README.md
+++ b/examples/nameko_sqlalchemy/README.md
@@ -46,7 +46,6 @@ Now the following command will setup the database, and start the server:
 
 ```bash
 ./run.sh
-
 ```
 
 Now head on over to postman and send POST request to:

--- a/examples/nameko_sqlalchemy/database.py
+++ b/examples/nameko_sqlalchemy/database.py
@@ -14,7 +14,7 @@ def init_db():
     # import all modules here that might define models so that
     # they will be registered properly on the metadata.  Otherwise
     # you will have to import them first before calling init_db()
-    from .models import Department, Employee, Role
+    from models import Department, Employee, Role
     Base.metadata.drop_all(bind=engine)
     Base.metadata.create_all(bind=engine)
 

--- a/examples/nameko_sqlalchemy/schema.py
+++ b/examples/nameko_sqlalchemy/schema.py
@@ -8,31 +8,28 @@ from graphene_sqlalchemy import SQLAlchemyConnectionField, SQLAlchemyObjectType
 
 
 class Department(SQLAlchemyObjectType):
-
     class Meta:
         model = DepartmentModel
-        interfaces = (relay.Node, )
+        interfaces = (relay.Node,)
 
 
 class Employee(SQLAlchemyObjectType):
-
     class Meta:
         model = EmployeeModel
-        interfaces = (relay.Node, )
+        interfaces = (relay.Node,)
 
 
 class Role(SQLAlchemyObjectType):
-
     class Meta:
         model = RoleModel
-        interfaces = (relay.Node, )
+        interfaces = (relay.Node,)
 
 
 class Query(graphene.ObjectType):
     node = relay.Node.Field()
-    all_employees = SQLAlchemyConnectionField(Employee)
-    all_roles = SQLAlchemyConnectionField(Role)
+    all_employees = SQLAlchemyConnectionField(Employee.connection)
+    all_roles = SQLAlchemyConnectionField(Role.connection)
     role = graphene.Field(Role)
 
 
-schema = graphene.Schema(query=Query, types=[Department, Employee, Role])
+schema = graphene.Schema(query=Query)

--- a/graphene_sqlalchemy/tests/test_query.py
+++ b/graphene_sqlalchemy/tests/test_query.py
@@ -1,5 +1,5 @@
 import graphene
-from graphene.relay import Connection, Node
+from graphene.relay import Node
 
 from ..converter import convert_sqlalchemy_composite
 from ..fields import SQLAlchemyConnectionField
@@ -96,14 +96,10 @@ def test_query_node(session):
             model = Article
             interfaces = (Node,)
 
-    class ArticleConnection(Connection):
-        class Meta:
-            node = ArticleNode
-
     class Query(graphene.ObjectType):
         node = Node.Field()
         reporter = graphene.Field(ReporterNode)
-        all_articles = SQLAlchemyConnectionField(ArticleConnection)
+        all_articles = SQLAlchemyConnectionField(ArticleNode.connection)
 
         def resolve_reporter(self, _info):
             return session.query(Reporter).first()
@@ -230,13 +226,9 @@ def test_custom_identifier(session):
             model = Editor
             interfaces = (Node,)
 
-    class EditorConnection(Connection):
-        class Meta:
-            node = EditorNode
-
     class Query(graphene.ObjectType):
         node = Node.Field()
-        all_editors = SQLAlchemyConnectionField(EditorConnection)
+        all_editors = SQLAlchemyConnectionField(EditorNode.connection)
 
     query = """
         query {

--- a/graphene_sqlalchemy/tests/test_sort_enums.py
+++ b/graphene_sqlalchemy/tests/test_sort_enums.py
@@ -2,7 +2,7 @@ import pytest
 import sqlalchemy as sa
 
 from graphene import Argument, Enum, List, ObjectType, Schema
-from graphene.relay import Connection, Node
+from graphene.relay import Node
 
 from ..fields import SQLAlchemyConnectionField
 from ..types import SQLAlchemyObjectType
@@ -249,22 +249,18 @@ def test_sort_query(session):
             model = Pet
             interfaces = (Node,)
 
-    class PetConnection(Connection):
-        class Meta:
-            node = PetNode
-
     class Query(ObjectType):
-        defaultSort = SQLAlchemyConnectionField(PetConnection)
-        nameSort = SQLAlchemyConnectionField(PetConnection)
-        multipleSort = SQLAlchemyConnectionField(PetConnection)
-        descSort = SQLAlchemyConnectionField(PetConnection)
+        defaultSort = SQLAlchemyConnectionField(PetNode.connection)
+        nameSort = SQLAlchemyConnectionField(PetNode.connection)
+        multipleSort = SQLAlchemyConnectionField(PetNode.connection)
+        descSort = SQLAlchemyConnectionField(PetNode.connection)
         singleColumnSort = SQLAlchemyConnectionField(
-            PetConnection, sort=Argument(PetNode.sort_enum())
+            PetNode.connection, sort=Argument(PetNode.sort_enum())
         )
         noDefaultSort = SQLAlchemyConnectionField(
-            PetConnection, sort=PetNode.sort_argument(has_default=False)
+            PetNode.connection, sort=PetNode.sort_argument(has_default=False)
         )
-        noSort = SQLAlchemyConnectionField(PetConnection, sort=None)
+        noSort = SQLAlchemyConnectionField(PetNode.connection, sort=None)
 
     query = """
         query sortTest {


### PR DESCRIPTION
In most cases, it is not recommended to create custom connection classes since it can conflict with the ones auto-created by `SQLAlchemyObjectType`.  This should prevent a lot of confusion: https://github.com/graphql-python/graphene-sqlalchemy/issues/153, https://github.com/graphql-python/graphene-sqlalchemy/issues/65

If needed, it's possible to access the auto-created connections like this: `PetType.connection`

This also updates tests to keep things consistent.