### PR TITLE
Add additional sqlalchemy_utils types

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -27,6 +27,11 @@ try:
 except ImportError:
     sqlalchemy_utils = DummyImport()
 
+try:
+    from geoalchemy2.elements import Geometry
+except ImportError:
+    Geometry = object
+
 
 is_selectin_available = getattr(strategies, 'SelectInLoader', None)
 
@@ -194,6 +199,7 @@ def convert_sqlalchemy_type(type, column, registry=None):
 @convert_sqlalchemy_type.register(sqlalchemy_utils.EmailType)
 @convert_sqlalchemy_type.register(sqlalchemy_utils.URLType)
 @convert_sqlalchemy_type.register(sqlalchemy_utils.IPAddressType)
+@convert_sqlalchemy_type.register(Geometry)
 def convert_column_to_string(type, column, registry=None):
     return String
 

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -13,7 +13,7 @@ from graphene.relay import Node
 from graphene.types.datetime import DateTime
 from graphene.types.json import JSONString
 
-from ..converter import (convert_sqlalchemy_column,
+from ..converter import (DummyImport, convert_sqlalchemy_column,
                          convert_sqlalchemy_composite,
                          convert_sqlalchemy_relationship)
 from ..fields import (UnsortedSQLAlchemyConnectionField,
@@ -369,3 +369,9 @@ def test_should_unknown_sqlalchemy_composite_raise_exception():
             Registry(),
             mock_resolver,
         )
+
+
+def test_dummy_import():
+    """The dummy module returns 'object' for a query for any member"""
+    dummy_module = DummyImport()
+    assert dummy_module.foo == object


### PR DESCRIPTION
This change adds most of the trivial string types from sqlalchemy_utils:
UUIDType, EmailType, URLType, and IPAddressType.