### PR TITLE
Simplify import of version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,5 @@
-import ast
-import re
-import sys
-
 from setuptools import find_packages, setup
-
-_version_re = re.compile(r"__version__\s+=\s+(.*)")
-
-with open("graphene_sqlalchemy/__init__.py", "rb") as f:
-    version = str(
-        ast.literal_eval(_version_re.search(f.read().decode("utf-8")).group(1))
-    )
+from graphene_sqlalchemy import __version__ as version
 
 requirements = [
     # To keep things simple, we only support newer versions of Graphene


### PR DESCRIPTION
I found the previous implementation to import the version number too complex, but maybe I have missed something here? If possible this should be simplified.