### PR TITLE
Get default type of hybrid_property from type annotation

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -260,27 +260,27 @@ def convert_json_type_to_string(type, column, registry=None):
     return JSONString
 
 
-def convert_hybrid_type(type, column):
-    if type in [str, datetime.date, datetime.time]:
+def convert_hybrid_type(type_, column):
+    if type_ in [str, datetime.date, datetime.time]:
         return String
-    elif type == datetime.datetime:
+    elif type_ == datetime.datetime:
         from graphene.types.datetime import DateTime
         return DateTime
-    elif type == int:
+    elif type_ == int:
         return Int
-    elif type == float:
+    elif type_ == float:
         return Float
-    elif type == bool:
+    elif type_ == bool:
         return Boolean
-    elif getattr(type, "__origin__", None) == list:  # check for typing.List[T]
-        args = getattr(type, "__args__", [])
+    elif getattr(type_, "__origin__", None) == list:  # check for typing.List[T]
+        args = getattr(type_, "__args__", [])
         if len(args) != 1:
             return String  # Unknown fallback
 
         inner_type = convert_hybrid_type(args[0], column)
         return List(inner_type)
-    elif getattr(type, "__name__", None) == "list":  # check for list[T]
-        args = getattr(type, "__args__", [])
+    elif getattr(type_, "__name__", None) == "list":  # check for list[T]
+        args = getattr(type_, "__args__", [])
         if len(args) != 1:
             return String  # Unknown fallback
 

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -260,26 +260,30 @@ def convert_json_type_to_string(type, column, registry=None):
     return JSONString
 
 
+def _check_type(type_, args):
+    return type_ in (args + [x.__name__ for x in args])
+
+
 def convert_hybrid_type(type_, column):
-    if type_ in [str, datetime.date, datetime.time]:
+    if _check_type(type_, [str, datetime.date, datetime.time]):
         return String
-    elif type_ == datetime.datetime:
+    elif _check_type(type_, [datetime.datetime]):
         from graphene.types.datetime import DateTime
         return DateTime
-    elif type_ == int:
+    elif _check_type(type_, [Int]):
         return Int
-    elif type_ == float:
+    elif _check_type(type_, [float]):
         return Float
-    elif type_ == bool:
+    elif _check_type(type_, [bool]):
         return Boolean
-    elif getattr(type_, "__origin__", None) == list:  # check for typing.List[T]
+    elif _check_type(getattr(type_, "__origin__", None), [list]):  # check for typing.List[T]
         args = getattr(type_, "__args__", [])
         if len(args) != 1:
             return String  # Unknown fallback
 
         inner_type = convert_hybrid_type(args[0], column)
         return List(inner_type)
-    elif getattr(type_, "__name__", None) == "list":  # check for list[T]
+    elif _check_type(getattr(type_, "__name__", None), [list]):  # check for list[T]
         args = getattr(type_, "__args__", [])
         if len(args) != 1:
             return String  # Unknown fallback

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -1,4 +1,5 @@
 import datetime
+import warnings
 from functools import singledispatch
 
 from sqlalchemy import types
@@ -279,6 +280,7 @@ def convert_hybrid_type(type_, column):
     elif _check_type(getattr(type_, "__origin__", None), [list]):  # check for typing.List[T]
         args = getattr(type_, "__args__", [])
         if len(args) != 1:
+            warnings.warn('seems to typing.List[T] but it has more than one argument', RuntimeWarning, stacklevel=2)
             return String  # Unknown fallback
 
         inner_type = convert_hybrid_type(args[0], column)
@@ -286,9 +288,11 @@ def convert_hybrid_type(type_, column):
     elif _check_type(getattr(type_, "__name__", None), [list]):  # check for list[T]
         args = getattr(type_, "__args__", [])
         if len(args) != 1:
+            warnings.warn('seems to list[T] but it has more than one argument', RuntimeWarning)
             return String  # Unknown fallback
 
         inner_type = convert_hybrid_type(args[0], column)
         return List(inner_type)
 
+    warnings.warn('Could not convert type %s to graphene type' % type_, RuntimeWarning)
     return String

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -1,3 +1,4 @@
+import datetime
 from functools import singledispatch
 
 from sqlalchemy import types
@@ -115,8 +116,9 @@ def _convert_o2m_or_m2m_relationship(relationship_prop, obj_type, batching, conn
 
 def convert_sqlalchemy_hybrid_method(hybrid_prop, resolver, **field_kwargs):
     if 'type_' not in field_kwargs:
-        # TODO The default type should be dependent on the type of the property propety.
-        field_kwargs['type_'] = String
+        field_kwargs['type_'] = convert_hybrid_type(
+            hybrid_prop.fget.__annotations__.get('return', str), hybrid_prop
+        )
 
     return Field(
         resolver=resolver,
@@ -256,3 +258,33 @@ def convert_json_to_string(type, column, registry=None):
 @convert_sqlalchemy_type.register(JSONType)
 def convert_json_type_to_string(type, column, registry=None):
     return JSONString
+
+
+def convert_hybrid_type(type, column):
+    if type in [str, datetime.date, datetime.time]:
+        return String
+    elif type == datetime.datetime:
+        from graphene.types.datetime import DateTime
+        return DateTime
+    elif type == int:
+        return Int
+    elif type == float:
+        return Float
+    elif type == bool:
+        return Boolean
+    elif getattr(type, "__origin__", None) == list:  # check for typing.List[T]
+        args = getattr(type, "__args__", [])
+        if len(args) != 1:
+            return String  # Unknown fallback
+
+        inner_type = convert_hybrid_type(args[0], column)
+        return List(inner_type)
+    elif getattr(type, "__name__", None) == "list":  # check for list[T]
+        args = getattr(type, "__args__", [])
+        if len(args) != 1:
+            return String  # Unknown fallback
+
+        inner_type = convert_hybrid_type(args[0], column)
+        return List(inner_type)
+
+    return String

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 
 import enum
+from typing import List
 
 from sqlalchemy import (Column, Date, Enum, ForeignKey, Integer, String, Table,
                         func, select)
@@ -68,6 +69,26 @@ class Reporter(Base):
     @hybrid_property
     def hybrid_prop(self):
         return self.first_name
+
+    @hybrid_property
+    def hybrid_prop_str(self) -> str:
+        return self.first_name
+
+    @hybrid_property
+    def hybrid_prop_int(self) -> int:
+        return 42
+
+    @hybrid_property
+    def hybrid_prop_float(self) -> float:
+        return 42.3
+
+    @hybrid_property
+    def hybrid_prop_bool(self) -> bool:
+        return True
+
+    @hybrid_property
+    def hybrid_prop_list(self) -> List[int]:
+        return [1, 2, 3]
 
     column_prop = column_property(
         select([func.cast(func.count(id), Integer)]), doc="Column property"

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -2,8 +2,8 @@ from unittest import mock
 
 import pytest
 
-from graphene import (Dynamic, Field, GlobalID, Int, List, Node, NonNull,
-                      ObjectType, Schema, String)
+from graphene import (Boolean, Dynamic, Field, Float, GlobalID, Int, List,
+                      Node, NonNull, ObjectType, Schema, String)
 from graphene.relay import Connection
 
 from ..converter import convert_sqlalchemy_composite
@@ -83,6 +83,11 @@ def test_sqlalchemy_default_fields():
         "composite_prop",
         # Hybrid
         "hybrid_prop",
+        "hybrid_prop_str",
+        "hybrid_prop_int",
+        "hybrid_prop_float",
+        "hybrid_prop_bool",
+        "hybrid_prop_list",
         # Relationship
         "pets",
         "articles",
@@ -111,6 +116,36 @@ def test_sqlalchemy_default_fields():
     assert hybrid_prop.type == String
     # "doc" is ignored by hybrid_property
     assert hybrid_prop.description is None
+
+    # hybrid_property_str
+    hybrid_prop_str = ReporterType._meta.fields['hybrid_prop_str']
+    assert hybrid_prop_str.type == String
+    # "doc" is ignored by hybrid_property
+    assert hybrid_prop_str.description is None
+
+    # hybrid_property_int
+    hybrid_prop_int = ReporterType._meta.fields['hybrid_prop_int']
+    assert hybrid_prop_int.type == Int
+    # "doc" is ignored by hybrid_property
+    assert hybrid_prop_int.description is None
+
+    # hybrid_property_float
+    hybrid_prop_float = ReporterType._meta.fields['hybrid_prop_float']
+    assert hybrid_prop_float.type == Float
+    # "doc" is ignored by hybrid_property
+    assert hybrid_prop_float.description is None
+
+    # hybrid_property_bool
+    hybrid_prop_bool = ReporterType._meta.fields['hybrid_prop_bool']
+    assert hybrid_prop_bool.type == Boolean
+    # "doc" is ignored by hybrid_property
+    assert hybrid_prop_bool.description is None
+
+    # hybrid_property_list
+    hybrid_prop_list = ReporterType._meta.fields['hybrid_prop_list']
+    assert hybrid_prop_list.type == List(Int)
+    # "doc" is ignored by hybrid_property
+    assert hybrid_prop_list.description is None
 
     # relationship
     favorite_article_field = ReporterType._meta.fields['favorite_article']
@@ -179,6 +214,11 @@ def test_sqlalchemy_override_fields():
         # Then the automatic SQLAlchemy fields
         "id",
         "favorite_pet_kind",
+        "hybrid_prop_str",
+        "hybrid_prop_int",
+        "hybrid_prop_float",
+        "hybrid_prop_bool",
+        "hybrid_prop_list",
     ]
 
     first_name_field = ReporterType._meta.fields['first_name']
@@ -276,6 +316,11 @@ def test_exclude_fields():
         "favorite_pet_kind",
         "composite_prop",
         "hybrid_prop",
+        "hybrid_prop_str",
+        "hybrid_prop_int",
+        "hybrid_prop_float",
+        "hybrid_prop_bool",
+        "hybrid_prop_list",
         "pets",
         "articles",
         "favorite_article",
@@ -384,7 +429,7 @@ def test_custom_objecttype_registered():
 
     assert issubclass(CustomReporterType, ObjectType)
     assert CustomReporterType._meta.model == Reporter
-    assert len(CustomReporterType._meta.fields) == 11
+    assert len(CustomReporterType._meta.fields) == 16
 
 
 # Test Custom SQLAlchemyObjectType with Custom Options


### PR DESCRIPTION
Fix below TODO comment.
```
# TODO The default type should be dependent on the type of the property propety.
```

Examines the return type of the function of `hybrid_property` and converts it to the default graphene type.