### PR TITLE
Supplant @hybrid_property's type annotation support with `Optional[T]`

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -331,6 +331,18 @@ def convert_sqlalchemy_hybrid_property_type_time(arg):
     return Time
 
 
+@convert_sqlalchemy_hybrid_property_type.register(lambda x: getattr(x, '__origin__', None) == typing.Union)
+def convert_sqlalchemy_hybrid_property_type_option_t(arg):
+    # Option is actually Union[T, <class NoneType>]
+
+    # Just get the T out of the list of arguments by filtering out the NoneType
+    internal_type = next(filter(lambda x: not type(None) == x, arg.__args__))
+
+    graphql_internal_type = convert_sqlalchemy_hybrid_property_type(internal_type)
+
+    return graphql_internal_type
+
+
 @convert_sqlalchemy_hybrid_property_type.register(lambda x: getattr(x, '__origin__', None) in [list, typing.List])
 def convert_sqlalchemy_hybrid_property_type_list_t(arg):
     # type is either list[T] or List[T], generic argument at __args__[0]

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import datetime
 import enum
 from decimal import Decimal
-from typing import List, Tuple
+from typing import List, Optional, Tuple
 
 from sqlalchemy import (Column, Date, Enum, ForeignKey, Integer, String, Table,
                         func, select)
@@ -217,3 +217,9 @@ class ShoppingCart(Base):
     @hybrid_property
     def hybrid_prop_self_referential_list(self) -> List['ShoppingCart']:
         return [ShoppingCart(id=1)]
+
+    # Optional[T]
+
+    @hybrid_property
+    def hybrid_prop_optional_self_referential(self) -> Optional['ShoppingCart']:
+        return None

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -452,6 +452,8 @@ def test_sqlalchemy_hybrid_property_type_inference():
         # Self Referential List
         "hybrid_prop_self_referential": ShoppingCartType,
         "hybrid_prop_self_referential_list": List(ShoppingCartType),
+        # Optionals
+        "hybrid_prop_optional_self_referential": ShoppingCartType,
     }
 
     assert sorted(list(ShoppingCartType._meta.fields.keys())) == sorted([


### PR DESCRIPTION
This PR supplants the previous "hybrid property type inference" work by adding support for `Optional[T]` as well. 

Currently, all inferred hybrid properties are optional, so this work is mainly done for completeness sake (and so that we can have `Option[T]` properly rendering `T` in GraphQL objects).

An additional test was written to cover this new capability.