### PR TITLE
Pick up the docstrings of hybrid properties

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -130,6 +130,9 @@ def convert_sqlalchemy_hybrid_method(hybrid_prop, resolver, **field_kwargs):
     if 'type_' not in field_kwargs:
         field_kwargs['type_'] = convert_hybrid_property_return_type(hybrid_prop)
 
+    if 'description' not in field_kwargs:
+        field_kwargs['description'] = getattr(hybrid_prop, "__doc__", None)
+
     return Field(
         resolver=resolver,
         **field_kwargs

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -69,6 +69,11 @@ class Reporter(Base):
     favorite_article = relationship("Article", uselist=False)
 
     @hybrid_property
+    def hybrid_prop_with_doc(self):
+        """Docstring test"""
+        return self.first_name
+
+    @hybrid_property
     def hybrid_prop(self):
         return self.first_name
 

--- a/graphene_sqlalchemy/tests/test_types.py
+++ b/graphene_sqlalchemy/tests/test_types.py
@@ -85,6 +85,7 @@ def test_sqlalchemy_default_fields():
         # Composite
         "composite_prop",
         # Hybrid
+        "hybrid_prop_with_doc",
         "hybrid_prop",
         "hybrid_prop_str",
         "hybrid_prop_int",
@@ -150,6 +151,12 @@ def test_sqlalchemy_default_fields():
     # "doc" is ignored by hybrid_property
     assert hybrid_prop_list.description is None
 
+    # hybrid_prop_with_doc
+    hybrid_prop_with_doc = ReporterType._meta.fields['hybrid_prop_with_doc']
+    assert hybrid_prop_with_doc.type == String
+    # docstring is picked up from hybrid_prop_with_doc
+    assert hybrid_prop_with_doc.description == "Docstring test"
+
     # relationship
     favorite_article_field = ReporterType._meta.fields['favorite_article']
     assert isinstance(favorite_article_field, Dynamic)
@@ -183,6 +190,7 @@ def test_sqlalchemy_override_fields():
         composite_prop = ORMField()
 
         # hybrid_property
+        hybrid_prop_with_doc = ORMField(description='Overridden')
         hybrid_prop = ORMField(description='Overridden')
 
         # relationships
@@ -210,6 +218,7 @@ def test_sqlalchemy_override_fields():
         "email_v2",
         "column_prop",
         "composite_prop",
+        "hybrid_prop_with_doc",
         "hybrid_prop",
         "favorite_article",
         "articles",
@@ -249,6 +258,11 @@ def test_sqlalchemy_override_fields():
     assert hybrid_prop_field.type == String
     assert hybrid_prop_field.description == "Overridden"
     assert hybrid_prop_field.deprecation_reason is None
+
+    hybrid_prop_with_doc_field = ReporterType._meta.fields['hybrid_prop_with_doc']
+    assert hybrid_prop_with_doc_field.type == String
+    assert hybrid_prop_with_doc_field.description == "Overridden"
+    assert hybrid_prop_with_doc_field.deprecation_reason is None
 
     column_prop_field_v2 = ReporterType._meta.fields['column_prop']
     assert column_prop_field_v2.type == String
@@ -318,6 +332,7 @@ def test_exclude_fields():
         "email",
         "favorite_pet_kind",
         "composite_prop",
+        "hybrid_prop_with_doc",
         "hybrid_prop",
         "hybrid_prop_str",
         "hybrid_prop_int",
@@ -432,7 +447,7 @@ def test_custom_objecttype_registered():
 
     assert issubclass(CustomReporterType, ObjectType)
     assert CustomReporterType._meta.model == Reporter
-    assert len(CustomReporterType._meta.fields) == 16
+    assert len(CustomReporterType._meta.fields) == 17
 
 
 # Test Custom SQLAlchemyObjectType with Custom Options


### PR DESCRIPTION
@erikwrede, I had deleted my repo, so this is a new PR to replace #298.

The issue that I had with SQA <1.3.19 regarding the ordering of all_orm_descriptors
is resolved by sorting `list(ReporterType._meta.fields.keys())` .