### PR TITLE
Enable sorting when batching is enabled

### DIFF
--- a/graphene_sqlalchemy/batching.py
+++ b/graphene_sqlalchemy/batching.py
@@ -1,4 +1,6 @@
+"""The dataloader uses "select in loading" strategy to load related entities."""
 from asyncio import get_event_loop
+from typing import Dict
 
 import aiodataloader
 import sqlalchemy
@@ -7,102 +9,106 @@ from sqlalchemy.orm.query import QueryContext
 
 from .utils import is_sqlalchemy_version_less_than
 
+
+class RelationshipLoader(aiodataloader.DataLoader):
+    cache = False
+
+    def __init__(self, relationship_prop, selectin_loader):
+        super().__init__()
+        self.relationship_prop = relationship_prop
+        self.selectin_loader = selectin_loader
+
+    async def batch_load_fn(self, parents):
+        """
+        Batch loads the relationships of all the parents as one SQL statement.
+
+        There is no way to do this out-of-the-box with SQLAlchemy but
+        we can piggyback on some internal APIs of the `selectin`
+        eager loading strategy. It's a bit hacky but it's preferable
+        than re-implementing and maintainnig a big chunk of the `selectin`
+        loader logic ourselves.
+
+        The approach here is to build a regular query that
+        selects the parent and `selectin` load the relationship.
+        But instead of having the query emits 2 `SELECT` statements
+        when callling `all()`, we skip the first `SELECT` statement
+        and jump right before the `selectin` loader is called.
+        To accomplish this, we have to construct objects that are
+        normally built in the first part of the query in order
+        to call directly `SelectInLoader._load_for_path`.
+
+        TODO Move this logic to a util in the SQLAlchemy repo as per
+            SQLAlchemy's main maitainer suggestion.
+            See https://git.io/JewQ7
+        """
+        child_mapper = self.relationship_prop.mapper
+        parent_mapper = self.relationship_prop.parent
+        session = Session.object_session(parents[0])
+
+        # These issues are very unlikely to happen in practice...
+        for parent in parents:
+            # assert parent.__mapper__ is parent_mapper
+            # All instances must share the same session
+            assert session is Session.object_session(parent)
+            # The behavior of `selectin` is undefined if the parent is dirty
+            assert parent not in session.dirty
+
+        # Should the boolean be set to False? Does it matter for our purposes?
+        states = [(sqlalchemy.inspect(parent), True) for parent in parents]
+
+        # For our purposes, the query_context will only used to get the session
+        query_context = None
+        if is_sqlalchemy_version_less_than('1.4'):
+            query_context = QueryContext(session.query(parent_mapper.entity))
+        else:
+            parent_mapper_query = session.query(parent_mapper.entity)
+            query_context = parent_mapper_query._compile_context()
+
+        if is_sqlalchemy_version_less_than('1.4'):
+            self.selectin_loader._load_for_path(
+                query_context,
+                parent_mapper._path_registry,
+                states,
+                None,
+                child_mapper,
+            )
+        else:
+            self.selectin_loader._load_for_path(
+                query_context,
+                parent_mapper._path_registry,
+                states,
+                None,
+                child_mapper,
+                None,
+            )
+        return [
+            getattr(parent, self.relationship_prop.key) for parent in parents
+        ]
+
+
 # Cache this across `batch_load_fn` calls
 # This is so SQL string generation is cached under-the-hood via `bakery`
 # Caching the relationship loader for each relationship prop.
-RELATIONSHIP_LOADERS_CACHE = {}
+RELATIONSHIP_LOADERS_CACHE: Dict[
+    sqlalchemy.orm.relationships.RelationshipProperty, RelationshipLoader
+] = {}
 
 
 def get_batch_resolver(relationship_prop):
-
-    class RelationshipLoader(aiodataloader.DataLoader):
-        cache = False
-
-        def __init__(self, relationship_prop, selectin_loader):
-            super().__init__()
-            self.relationship_prop = relationship_prop
-            self.selectin_loader = selectin_loader
-
-        async def batch_load_fn(self, parents):
-            """
-            Batch loads the relationships of all the parents as one SQL statement.
-
-            There is no way to do this out-of-the-box with SQLAlchemy but
-            we can piggyback on some internal APIs of the `selectin`
-            eager loading strategy. It's a bit hacky but it's preferable
-            than re-implementing and maintainnig a big chunk of the `selectin`
-            loader logic ourselves.
-
-            The approach here is to build a regular query that
-            selects the parent and `selectin` load the relationship.
-            But instead of having the query emits 2 `SELECT` statements
-            when callling `all()`, we skip the first `SELECT` statement
-            and jump right before the `selectin` loader is called.
-            To accomplish this, we have to construct objects that are
-            normally built in the first part of the query in order
-            to call directly `SelectInLoader._load_for_path`.
-
-            TODO Move this logic to a util in the SQLAlchemy repo as per
-              SQLAlchemy's main maitainer suggestion.
-              See https://git.io/JewQ7
-            """
-            child_mapper = self.relationship_prop.mapper
-            parent_mapper = self.relationship_prop.parent
-            session = Session.object_session(parents[0])
-
-            # These issues are very unlikely to happen in practice...
-            for parent in parents:
-                # assert parent.__mapper__ is parent_mapper
-                # All instances must share the same session
-                assert session is Session.object_session(parent)
-                # The behavior of `selectin` is undefined if the parent is dirty
-                assert parent not in session.dirty
-
-            # Should the boolean be set to False? Does it matter for our purposes?
-            states = [(sqlalchemy.inspect(parent), True) for parent in parents]
-
-            # For our purposes, the query_context will only used to get the session
-            query_context = None
-            if is_sqlalchemy_version_less_than('1.4'):
-                query_context = QueryContext(session.query(parent_mapper.entity))
-            else:
-                parent_mapper_query = session.query(parent_mapper.entity)
-                query_context = parent_mapper_query._compile_context()
-
-            if is_sqlalchemy_version_less_than('1.4'):
-                self.selectin_loader._load_for_path(
-                    query_context,
-                    parent_mapper._path_registry,
-                    states,
-                    None,
-                    child_mapper
-                )
-            else:
-                self.selectin_loader._load_for_path(
-                    query_context,
-                    parent_mapper._path_registry,
-                    states,
-                    None,
-                    child_mapper,
-                    None
-                )
-            return [getattr(parent, self.relationship_prop.key) for parent in parents]
+    """get the resolve function for the given relationship."""
 
     def _get_loader(relationship_prop):
         """Retrieve the cached loader of the given relationship."""
         loader = RELATIONSHIP_LOADERS_CACHE.get(relationship_prop, None)
-        if loader is None:
+        if loader is None or loader.loop != get_event_loop():
             selectin_loader = strategies.SelectInLoader(
-                relationship_prop,
-                (('lazy', 'selectin'),)
+                relationship_prop, (('lazy', 'selectin'),)
             )
             loader = RelationshipLoader(
                 relationship_prop=relationship_prop,
-                selectin_loader=selectin_loader
+                selectin_loader=selectin_loader,
             )
             RELATIONSHIP_LOADERS_CACHE[relationship_prop] = loader
-        else:
-            loader.loop = get_event_loop()
         return loader
 
     loader = _get_loader(relationship_prop)

--- a/graphene_sqlalchemy/batching.py
+++ b/graphene_sqlalchemy/batching.py
@@ -95,7 +95,7 @@ RELATIONSHIP_LOADERS_CACHE: Dict[
 
 
 def get_batch_resolver(relationship_prop):
-    """get the resolve function for the given relationship."""
+    """Get the resolve function for the given relationship."""
 
     def _get_loader(relationship_prop):
         """Retrieve the cached loader of the given relationship."""

--- a/graphene_sqlalchemy/enums.py
+++ b/graphene_sqlalchemy/enums.py
@@ -144,9 +144,9 @@ def sort_enum_for_object_type(
             column = orm_field.columns[0]
             if only_indexed and not (column.primary_key or column.index):
                 continue
-            asc_name = get_name(column.key, True)
+            asc_name = get_name(field_name, True)
             asc_value = EnumValue(asc_name, column.asc())
-            desc_name = get_name(column.key, False)
+            desc_name = get_name(field_name, False)
             desc_value = EnumValue(desc_name, column.desc())
             if column.primary_key:
                 default.append(asc_value)

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -14,7 +14,7 @@ from .batching import get_batch_resolver
 from .utils import EnumValue, get_query
 
 
-class UnsortedSQLAlchemyConnectionField(ConnectionField):
+class SQLAlchemyConnectionField(ConnectionField):
     @property
     def type(self):
         from .types import SQLAlchemyObjectType
@@ -37,13 +37,45 @@ class UnsortedSQLAlchemyConnectionField(ConnectionField):
         )
         return nullable_type.connection
 
+    def __init__(self, type_, *args, **kwargs):
+        nullable_type = get_nullable_type(type_)
+        if "sort" not in kwargs and nullable_type and issubclass(nullable_type, Connection):
+            # Let super class raise if type is not a Connection
+            try:
+                kwargs.setdefault("sort", nullable_type.Edge.node._type.sort_argument())
+            except (AttributeError, TypeError):
+                raise TypeError(
+                    'Cannot create sort argument for {}. A model is required. Set the "sort" argument'
+                    " to None to disabling the creation of the sort query argument".format(
+                        nullable_type.__name__
+                    )
+                )
+        elif "sort" in kwargs and kwargs["sort"] is None:
+            del kwargs["sort"]
+        super(SQLAlchemyConnectionField, self).__init__(type_, *args, **kwargs)
+
     @property
     def model(self):
         return get_nullable_type(self.type)._meta.node._meta.model
 
     @classmethod
-    def get_query(cls, model, info, **args):
-        return get_query(model, info.context)
+    def get_query(cls, model, info, sort=None, **args):
+        query = get_query(model, info.context)
+        if sort is not None:
+            if not isinstance(sort, list):
+                sort = [sort]
+            sort_args = []
+            # ensure consistent handling of graphene Enums, enum values and
+            # plain strings
+            for item in sort:
+                if isinstance(item, enum.Enum):
+                    sort_args.append(item.value.value)
+                elif isinstance(item, EnumValue):
+                    sort_args.append(item.value)
+                else:
+                    sort_args.append(item)
+            query = query.order_by(*sort_args)
+        return query
 
     @classmethod
     def resolve_connection(cls, connection_type, model, info, args, resolved):
@@ -90,43 +122,16 @@ class UnsortedSQLAlchemyConnectionField(ConnectionField):
         )
 
 
-# TODO Rename this to SortableSQLAlchemyConnectionField
-class SQLAlchemyConnectionField(UnsortedSQLAlchemyConnectionField):
+# TODO Remove in next major version
+class UnsortedSQLAlchemyConnectionField(SQLAlchemyConnectionField):
     def __init__(self, type_, *args, **kwargs):
-        nullable_type = get_nullable_type(type_)
-        if "sort" not in kwargs and issubclass(nullable_type, Connection):
-            # Let super class raise if type is not a Connection
-            try:
-                kwargs.setdefault("sort", nullable_type.Edge.node._type.sort_argument())
-            except (AttributeError, TypeError):
-                raise TypeError(
-                    'Cannot create sort argument for {}. A model is required. Set the "sort" argument'
-                    " to None to disabling the creation of the sort query argument".format(
-                        nullable_type.__name__
-                    )
-                )
-        elif "sort" in kwargs and kwargs["sort"] is None:
-            del kwargs["sort"]
-        super(SQLAlchemyConnectionField, self).__init__(type_, *args, **kwargs)
-
-    @classmethod
-    def get_query(cls, model, info, sort=None, **args):
-        query = get_query(model, info.context)
-        if sort is not None:
-            if not isinstance(sort, list):
-                sort = [sort]
-            sort_args = []
-            # ensure consistent handling of graphene Enums, enum values and
-            # plain strings
-            for item in sort:
-                if isinstance(item, enum.Enum):
-                    sort_args.append(item.value.value)
-                elif isinstance(item, EnumValue):
-                    sort_args.append(item.value)
-                else:
-                    sort_args.append(item)
-            query = query.order_by(*sort_args)
-        return query
+        super(UnsortedSQLAlchemyConnectionField, self).__init__(type_, *args, **kwargs)
+        warnings.warn(
+            "UnsortedSQLAlchemyConnectionField is deprecated and will be removed in the next "
+            "major version. Use SQLAlchemyConnectionField instead and set `sort = None` "
+            "if you want to disable sorting.",
+            DeprecationWarning,
+        )
 
 
 class BatchSQLAlchemyConnectionField(SQLAlchemyConnectionField):

--- a/graphene_sqlalchemy/fields.py
+++ b/graphene_sqlalchemy/fields.py
@@ -125,13 +125,19 @@ class SQLAlchemyConnectionField(ConnectionField):
 # TODO Remove in next major version
 class UnsortedSQLAlchemyConnectionField(SQLAlchemyConnectionField):
     def __init__(self, type_, *args, **kwargs):
-        super(UnsortedSQLAlchemyConnectionField, self).__init__(type_, *args, **kwargs)
+        if "sort" in kwargs and kwargs["sort"] is not None:
+            warnings.warn(
+                "UnsortedSQLAlchemyConnectionField does not support sorting. "
+                "All sorting arguments will be ignored."
+            )
+            kwargs["sort"] = None
         warnings.warn(
             "UnsortedSQLAlchemyConnectionField is deprecated and will be removed in the next "
-            "major version. Use SQLAlchemyConnectionField instead and set `sort = None` "
-            "if you want to disable sorting.",
+            "major version. Use SQLAlchemyConnectionField instead and either don't "
+            "provide the `sort` argument or set it to None if you do not want sorting.",
             DeprecationWarning,
         )
+        super(UnsortedSQLAlchemyConnectionField, self).__init__(type_, *args, **kwargs)
 
 
 class BatchSQLAlchemyConnectionField(SQLAlchemyConnectionField):

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -110,6 +110,24 @@ class Article(Base):
     headline = Column(String(100))
     pub_date = Column(Date())
     reporter_id = Column(Integer(), ForeignKey("reporters.id"))
+    readers = relationship(
+        "Reader", secondary="articles_readers", back_populates="articles"
+    )
+
+
+class Reader(Base):
+    __tablename__ = "readers"
+    id = Column(Integer(), primary_key=True)
+    name = Column(String(100))
+    articles = relationship(
+        "Article", secondary="articles_readers", back_populates="readers"
+    )
+
+
+class ArticleReader(Base):
+    __tablename__ = "articles_readers"
+    article_id = Column(Integer(), ForeignKey("articles.id"), primary_key=True)
+    reader_id = Column(Integer(), ForeignKey("readers.id"), primary_key=True)
 
 
 class ReflectedEditor(type):

--- a/graphene_sqlalchemy/tests/test_batching.py
+++ b/graphene_sqlalchemy/tests/test_batching.py
@@ -5,13 +5,13 @@ import logging
 import pytest
 
 import graphene
-from graphene import relay
+from graphene import Connection, relay
 
 from ..fields import (BatchSQLAlchemyConnectionField,
                       default_connection_field_factory)
 from ..types import ORMField, SQLAlchemyObjectType
 from ..utils import is_sqlalchemy_version_less_than
-from .models import Article, HairKind, Pet, Reporter
+from .models import Article, HairKind, Pet, Reader, Reporter
 from .utils import remove_cache_miss_stat, to_std_dicts
 
 
@@ -73,6 +73,40 @@ def get_schema():
     return graphene.Schema(query=Query)
 
 
+def get_full_relay_schema():
+    class ReporterType(SQLAlchemyObjectType):
+        class Meta:
+            model = Reporter
+            name = "Reporter"
+            interfaces = (relay.Node,)
+            batching = True
+            connection_class = Connection
+
+    class ArticleType(SQLAlchemyObjectType):
+        class Meta:
+            model = Article
+            name = "Article"
+            interfaces = (relay.Node,)
+            batching = True
+            connection_class = Connection
+
+    class ReaderType(SQLAlchemyObjectType):
+        class Meta:
+            model = Reader
+            name = "Reader"
+            interfaces = (relay.Node,)
+            batching = True
+            connection_class = Connection
+
+    class Query(graphene.ObjectType):
+        node = relay.Node.Field()
+        articles = BatchSQLAlchemyConnectionField(ArticleType.connection)
+        reporters = BatchSQLAlchemyConnectionField(ReporterType.connection)
+        readers = BatchSQLAlchemyConnectionField(ReaderType.connection)
+
+    return graphene.Schema(query=Query)
+
+
 if is_sqlalchemy_version_less_than('1.2'):
     pytest.skip('SQL batching only works for SQLAlchemy 1.2+', allow_module_level=True)
 
@@ -82,11 +116,11 @@ async def test_many_to_one(session_factory):
     session = session_factory()
 
     reporter_1 = Reporter(
-      first_name='Reporter_1',
+        first_name='Reporter_1',
     )
     session.add(reporter_1)
     reporter_2 = Reporter(
-      first_name='Reporter_2',
+        first_name='Reporter_2',
     )
     session.add(reporter_2)
 
@@ -138,20 +172,20 @@ async def test_many_to_one(session_factory):
     assert not result.errors
     result = to_std_dicts(result.data)
     assert result == {
-      "articles": [
-        {
-          "headline": "Article_1",
-          "reporter": {
-            "firstName": "Reporter_1",
-          },
-        },
-        {
-          "headline": "Article_2",
-          "reporter": {
-            "firstName": "Reporter_2",
-          },
-        },
-      ],
+        "articles": [
+            {
+                "headline": "Article_1",
+                "reporter": {
+                    "firstName": "Reporter_1",
+                },
+            },
+            {
+                "headline": "Article_2",
+                "reporter": {
+                    "firstName": "Reporter_2",
+                },
+            },
+        ],
     }
 
 
@@ -160,11 +194,11 @@ async def test_one_to_one(session_factory):
     session = session_factory()
 
     reporter_1 = Reporter(
-      first_name='Reporter_1',
+        first_name='Reporter_1',
     )
     session.add(reporter_1)
     reporter_2 = Reporter(
-      first_name='Reporter_2',
+        first_name='Reporter_2',
     )
     session.add(reporter_2)
 
@@ -185,14 +219,14 @@ async def test_one_to_one(session_factory):
         # Starts new session to fully reset the engine / connection logging level
         session = session_factory()
         result = await schema.execute_async("""
-          query {
-            reporters {
-              firstName
-              favoriteArticle {
-                headline
-              }
+            query {
+                reporters {
+                    firstName
+                    favoriteArticle {
+                        headline
+                    }
+                }
             }
-          }
         """, context_value={"session": session})
         messages = sqlalchemy_logging_handler.messages
 
@@ -216,20 +250,20 @@ async def test_one_to_one(session_factory):
     assert not result.errors
     result = to_std_dicts(result.data)
     assert result == {
-      "reporters": [
-        {
-          "firstName": "Reporter_1",
-          "favoriteArticle": {
-            "headline": "Article_1",
-          },
-        },
-        {
-          "firstName": "Reporter_2",
-          "favoriteArticle": {
-            "headline": "Article_2",
-          },
-        },
-      ],
+        "reporters": [
+            {
+                "firstName": "Reporter_1",
+                "favoriteArticle": {
+                    "headline": "Article_1",
+                },
+            },
+            {
+                "firstName": "Reporter_2",
+                "favoriteArticle": {
+                    "headline": "Article_2",
+                },
+            },
+        ],
     }
 
 
@@ -238,11 +272,11 @@ async def test_one_to_many(session_factory):
     session = session_factory()
 
     reporter_1 = Reporter(
-      first_name='Reporter_1',
+        first_name='Reporter_1',
     )
     session.add(reporter_1)
     reporter_2 = Reporter(
-      first_name='Reporter_2',
+        first_name='Reporter_2',
     )
     session.add(reporter_2)
 
@@ -271,18 +305,18 @@ async def test_one_to_many(session_factory):
         # Starts new session to fully reset the engine / connection logging level
         session = session_factory()
         result = await schema.execute_async("""
-          query {
-            reporters {
-              firstName
-              articles(first: 2) {
-                edges {
-                  node {
-                    headline
-                  }
+            query {
+                reporters {
+                    firstName
+                    articles(first: 2) {
+                        edges {
+                            node {
+                                headline
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
         """, context_value={"session": session})
         messages = sqlalchemy_logging_handler.messages
 
@@ -306,42 +340,42 @@ async def test_one_to_many(session_factory):
     assert not result.errors
     result = to_std_dicts(result.data)
     assert result == {
-      "reporters": [
-        {
-          "firstName": "Reporter_1",
-          "articles": {
-            "edges": [
-              {
-                "node": {
-                  "headline": "Article_1",
+        "reporters": [
+            {
+                "firstName": "Reporter_1",
+                "articles": {
+                    "edges": [
+                        {
+                            "node": {
+                                "headline": "Article_1",
+                            },
+                        },
+                        {
+                            "node": {
+                                "headline": "Article_2",
+                            },
+                        },
+                    ],
                 },
-              },
-              {
-                "node": {
-                  "headline": "Article_2",
+            },
+            {
+                "firstName": "Reporter_2",
+                "articles": {
+                    "edges": [
+                        {
+                            "node": {
+                                "headline": "Article_3",
+                            },
+                        },
+                        {
+                            "node": {
+                                "headline": "Article_4",
+                            },
+                        },
+                    ],
                 },
-              },
-            ],
-          },
-        },
-        {
-          "firstName": "Reporter_2",
-          "articles": {
-            "edges": [
-              {
-                "node": {
-                  "headline": "Article_3",
-                },
-              },
-              {
-                "node": {
-                  "headline": "Article_4",
-                },
-              },
-            ],
-          },
-        },
-      ],
+            },
+        ],
     }
 
 
@@ -350,11 +384,11 @@ async def test_many_to_many(session_factory):
     session = session_factory()
 
     reporter_1 = Reporter(
-      first_name='Reporter_1',
+        first_name='Reporter_1',
     )
     session.add(reporter_1)
     reporter_2 = Reporter(
-      first_name='Reporter_2',
+        first_name='Reporter_2',
     )
     session.add(reporter_2)
 
@@ -385,18 +419,18 @@ async def test_many_to_many(session_factory):
         # Starts new session to fully reset the engine / connection logging level
         session = session_factory()
         result = await schema.execute_async("""
-          query {
-            reporters {
-              firstName
-              pets(first: 2) {
-                edges {
-                  node {
-                    name
-                  }
+            query {
+                reporters {
+                    firstName
+                    pets(first: 2) {
+                        edges {
+                            node {
+                                name
+                            }
+                        }
+                    }
                 }
-              }
             }
-          }
         """, context_value={"session": session})
         messages = sqlalchemy_logging_handler.messages
 
@@ -420,42 +454,42 @@ async def test_many_to_many(session_factory):
     assert not result.errors
     result = to_std_dicts(result.data)
     assert result == {
-      "reporters": [
-        {
-          "firstName": "Reporter_1",
-          "pets": {
-            "edges": [
-              {
-                "node": {
-                  "name": "Pet_1",
+        "reporters": [
+            {
+                "firstName": "Reporter_1",
+                "pets": {
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "Pet_1",
+                            },
+                        },
+                        {
+                            "node": {
+                                "name": "Pet_2",
+                            },
+                        },
+                    ],
                 },
-              },
-              {
-                "node": {
-                  "name": "Pet_2",
+            },
+            {
+                "firstName": "Reporter_2",
+                "pets": {
+                    "edges": [
+                        {
+                            "node": {
+                                "name": "Pet_3",
+                            },
+                        },
+                        {
+                            "node": {
+                                "name": "Pet_4",
+                            },
+                        },
+                    ],
                 },
-              },
-            ],
-          },
-        },
-        {
-          "firstName": "Reporter_2",
-          "pets": {
-            "edges": [
-              {
-                "node": {
-                  "name": "Pet_3",
-                },
-              },
-              {
-                "node": {
-                  "name": "Pet_4",
-                },
-              },
-            ],
-          },
-        },
-      ],
+            },
+        ],
     }
 
 
@@ -642,3 +676,99 @@ def test_connection_factory_field_overrides_batching_is_true(session_factory):
 
     select_statements = [message for message in messages if 'SELECT' in message and 'FROM articles' in message]
     assert len(select_statements) == 2
+
+
+@pytest.mark.asyncio
+async def test_batching_across_nested_relay_schema(session_factory):
+    session = session_factory()
+
+    for first_name in "fgerbhjikzutzxsdfdqqa":
+        reporter = Reporter(
+            first_name=first_name,
+        )
+        session.add(reporter)
+        article = Article(headline='Article')
+        article.reporter = reporter
+        session.add(article)
+        reader = Reader(name='Reader')
+        reader.articles = [article]
+        session.add(reader)
+
+    session.commit()
+    session.close()
+
+    schema = get_full_relay_schema()
+
+    with mock_sqlalchemy_logging_handler() as sqlalchemy_logging_handler:
+        # Starts new session to fully reset the engine / connection logging level
+        session = session_factory()
+        result = await schema.execute_async("""
+          query {
+            reporters {
+              edges {
+                node {
+                  firstName
+                  articles {
+                    edges {
+                      node {
+                        id
+                        readers {
+                          edges {
+                            node {
+                              name
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        """, context_value={"session": session})
+        messages = sqlalchemy_logging_handler.messages
+
+    result = to_std_dicts(result.data)
+    select_statements = [message for message in messages if 'SELECT' in message and 'FROM articles' in message]
+    assert len(select_statements) == 2
+
+
+@pytest.mark.asyncio
+async def test_sorting_can_be_used_with_batching_when_using_full_relay(session_factory):
+    session = session_factory()
+
+    for first_name, email in zip("cadbbb", "aaabac"):
+        reporter_1 = Reporter(
+            first_name=first_name,
+            email=email
+        )
+        session.add(reporter_1)
+        article_1 = Article(headline="headline")
+        article_1.reporter = reporter_1
+        session.add(article_1)
+
+    session.commit()
+    session.close()
+
+    schema = get_full_relay_schema()
+
+    session = session_factory()
+    result = await schema.execute_async("""
+      query {
+        reporters(sort: [FIRST_NAME_ASC, EMAIL_ASC]) {
+          edges {
+            node {
+              firstName
+              email
+            }
+          }
+        }
+      }
+    """, context_value={"session": session})
+
+    result = to_std_dicts(result.data)
+    assert [
+        r["node"]["firstName"] + r["node"]["email"]
+        for r in result["reporters"]["edges"]
+    ] == ['aa', 'ba', 'bb', 'bc', 'ca', 'da']

--- a/graphene_sqlalchemy/tests/test_fields.py
+++ b/graphene_sqlalchemy/tests/test_fields.py
@@ -64,6 +64,14 @@ def test_type_assert_object_has_connection():
 ##
 
 
+def test_unsorted_connection_field_removes_sort_arg_if_passed():
+    editor = UnsortedSQLAlchemyConnectionField(
+        Editor.connection,
+        sort=Editor.sort_argument(has_default=True)
+    )
+    assert "sort" not in editor.args
+
+
 def test_sort_added_by_default():
     field = SQLAlchemyConnectionField(Pet.connection)
     assert "sort" in field.args


### PR DESCRIPTION
This is a followup of our discussion from July 18th about batching and sorting. 
I took a deeper dive into the batching feature and have a better understanding of it now.
Basically the core issue was, that the batching resolver did not take care of running the initial query. Instead, the initial query had to be run "manually" in a custom "resolve_" field as indicated in the tests: https://github.com/graphql-python/graphene-sqlalchemy/blob/dfee3e9417cdb8a6ec67b5cd79ee203ce4f72ed7/graphene_sqlalchemy/tests/test_batching.py#L67
That of course bypassed the "get_query" function in the resolver and thus also made sorting "impossible".
Let me know what you think.