### PR TITLE
Add support for UUIDs in `@hybrid_property`

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -1,6 +1,7 @@
 import datetime
 import sys
 import typing
+import uuid
 import warnings
 from decimal import Decimal
 from functools import singledispatch
@@ -396,6 +397,11 @@ def convert_sqlalchemy_hybrid_property_type_date(arg):
 @convert_sqlalchemy_hybrid_property_type.register(value_equals(datetime.time))
 def convert_sqlalchemy_hybrid_property_type_time(arg):
     return graphene.Time
+
+
+@convert_sqlalchemy_hybrid_property_type.register(value_equals(uuid.UUID))
+def convert_sqlalchemy_hybrid_property_type_uuid(arg):
+    return graphene.UUID
 
 
 def is_union(arg) -> bool:

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import datetime
 import enum
+import uuid
 from decimal import Decimal
 from typing import List, Optional, Tuple
 
@@ -265,6 +266,21 @@ class ShoppingCart(Base):
 
     @hybrid_property
     def hybrid_prop_optional_self_referential(self) -> Optional["ShoppingCart"]:
+        return None
+
+    # UUIDS
+    @hybrid_property
+    def hybrid_prop_uuid(self) -> uuid.UUID:
+        return uuid.uuid4()
+
+    @hybrid_property
+    def hybrid_prop_uuid_list(self) -> List[uuid.UUID]:
+        return [
+            uuid.uuid4(),
+        ]
+
+    @hybrid_property
+    def hybrid_prop_optional_uuid(self) -> Optional[uuid.UUID]:
         return None
 
 

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -673,6 +673,10 @@ def test_sqlalchemy_hybrid_property_type_inference():
         "hybrid_prop_self_referential_list": graphene.List(ShoppingCartType),
         # Optionals
         "hybrid_prop_optional_self_referential": ShoppingCartType,
+        # UUIDs
+        "hybrid_prop_uuid": graphene.UUID,
+        "hybrid_prop_optional_uuid": graphene.UUID,
+        "hybrid_prop_uuid_list": graphene.List(graphene.UUID),
     }
 
     assert sorted(list(ShoppingCartType._meta.fields.keys())) == sorted(


### PR DESCRIPTION
We overlooked support for this fairly mundane type in the `@hybrid_property` work that we did. This PR addresses that shortcoming.