### PR TITLE
Make column not required if server_default exists

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -54,6 +54,10 @@ def is_column_nullable(column):
     return bool(getattr(column, "nullable", True))
 
 
+def get_column_server_default(column):
+    return getattr(column, "server_default", None)
+
+
 def convert_sqlalchemy_relationship(
     relationship_prop,
     obj_type,
@@ -212,7 +216,10 @@ def convert_sqlalchemy_column(column_prop, registry, resolver, **field_kwargs):
         "type_",
         convert_sqlalchemy_type(getattr(column, "type", None), column, registry),
     )
-    field_kwargs.setdefault("required", not is_column_nullable(column))
+    field_kwargs.setdefault(
+        "required",
+        not is_column_nullable(column) and get_column_server_default(column) is None,
+    )
     field_kwargs.setdefault("description", get_column_doc(column))
 
     return graphene.Field(resolver=resolver, **field_kwargs)


### PR DESCRIPTION
This PR does the following:

- A function called `get_column_server_default` which gets the given column's `server_default` value from the schema definition.
- Only sets the graphql field as required if it is `nullable` and doesn't have a `server_default value`.

This is because when there is a `server_default` set, we might not wanna have it be required, and have the `server_default` value be used when creating a new entry.