### PR TITLE
refactor!: use the same conversion system for hybrids and columns

### DIFF
--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -20,10 +20,10 @@ from .registry import Registry, get_global_registry
 from .resolvers import get_attr_resolver, get_custom_resolver
 from .utils import (
     DummyImport,
+    column_type_eq,
     registry_sqlalchemy_model_from_str,
     safe_isinstance,
     singledispatchbymatchfunction,
-    value_equals,
 )
 
 # We just use MapperProperties for type hints, they don't exist in sqlalchemy < 1.4
@@ -253,24 +253,24 @@ def convert_sqlalchemy_type(
     )
 
 
-@convert_sqlalchemy_type.register(value_equals(str))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.String))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Text))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Unicode))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.UnicodeText))
-@convert_sqlalchemy_type.register(value_equals(postgresql.INET))
-@convert_sqlalchemy_type.register(value_equals(postgresql.CIDR))
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.TSVectorType))
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.EmailType))
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.URLType))
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.IPAddressType))
+@convert_sqlalchemy_type.register(column_type_eq(str))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.String))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Text))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Unicode))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.UnicodeText))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.INET))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.CIDR))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.TSVectorType))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.EmailType))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.URLType))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.IPAddressType))
 def convert_column_to_string(type_arg: Any, **kwargs):
     return graphene.String
 
 
-@convert_sqlalchemy_type.register(value_equals(postgresql.UUID))
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.UUIDType))
-@convert_sqlalchemy_type.register(value_equals(uuid.UUID))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.UUID))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.UUIDType))
+@convert_sqlalchemy_type.register(column_type_eq(uuid.UUID))
 def convert_column_to_uuid(
     type_arg: Any,
     **kwargs,
@@ -278,8 +278,8 @@ def convert_column_to_uuid(
     return graphene.UUID
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.DateTime))
-@convert_sqlalchemy_type.register(value_equals(datetime.datetime))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.DateTime))
+@convert_sqlalchemy_type.register(column_type_eq(datetime.datetime))
 def convert_column_to_datetime(
     type_arg: Any,
     **kwargs,
@@ -287,8 +287,8 @@ def convert_column_to_datetime(
     return graphene.DateTime
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Time))
-@convert_sqlalchemy_type.register(value_equals(datetime.time))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Time))
+@convert_sqlalchemy_type.register(column_type_eq(datetime.time))
 def convert_column_to_time(
     type_arg: Any,
     **kwargs,
@@ -296,8 +296,8 @@ def convert_column_to_time(
     return graphene.Time
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Date))
-@convert_sqlalchemy_type.register(value_equals(datetime.date))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Date))
+@convert_sqlalchemy_type.register(column_type_eq(datetime.date))
 def convert_column_to_date(
     type_arg: Any,
     **kwargs,
@@ -305,9 +305,9 @@ def convert_column_to_date(
     return graphene.Date
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.SmallInteger))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Integer))
-@convert_sqlalchemy_type.register(value_equals(int))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.SmallInteger))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Integer))
+@convert_sqlalchemy_type.register(column_type_eq(int))
 def convert_column_to_int_or_id(
     type_arg: Any,
     column: Optional[Union[MapperProperty, hybrid_property]] = None,
@@ -319,8 +319,8 @@ def convert_column_to_int_or_id(
     )  # fixme drop the primary key processing in another pr
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Boolean))
-@convert_sqlalchemy_type.register(value_equals(bool))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Boolean))
+@convert_sqlalchemy_type.register(column_type_eq(bool))
 def convert_column_to_boolean(
     type_arg: Any,
     **kwargs,
@@ -328,10 +328,10 @@ def convert_column_to_boolean(
     return graphene.Boolean
 
 
-@convert_sqlalchemy_type.register(value_equals(float))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Float))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Numeric))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.BigInteger))
+@convert_sqlalchemy_type.register(column_type_eq(float))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Float))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Numeric))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.BigInteger))
 def convert_column_to_float(
     type_arg: Any,
     **kwargs,
@@ -339,8 +339,8 @@ def convert_column_to_float(
     return graphene.Float
 
 
-@convert_sqlalchemy_type.register(value_equals(postgresql.ENUM))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Enum))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.ENUM))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Enum))
 def convert_enum_to_enum(
     type_arg: Any,
     column: Optional[Union[MapperProperty, hybrid_property]] = None,
@@ -354,7 +354,7 @@ def convert_enum_to_enum(
 
 
 # TODO Make ChoiceType conversion consistent with other enums
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.ChoiceType))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.ChoiceType))
 def convert_choice_to_enum(
     type_arg: sqa_utils.ChoiceType,
     column: Optional[Union[MapperProperty, hybrid_property]] = None,
@@ -372,7 +372,7 @@ def convert_choice_to_enum(
         return graphene.Enum(name, column.type.choices)
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.ScalarListType))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.ScalarListType))
 def convert_scalar_list_to_list(
     type_arg: Any,
     **kwargs,
@@ -388,8 +388,8 @@ def init_array_list_recursive(inner_type, n):
     )
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.ARRAY))
-@convert_sqlalchemy_type.register(value_equals(postgresql.ARRAY))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.ARRAY))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.ARRAY))
 def convert_array_to_list(
     type_arg: Any,
     column: Optional[Union[MapperProperty, hybrid_property]] = None,
@@ -409,9 +409,9 @@ def convert_array_to_list(
     )
 
 
-@convert_sqlalchemy_type.register(value_equals(postgresql.HSTORE))
-@convert_sqlalchemy_type.register(value_equals(postgresql.JSON))
-@convert_sqlalchemy_type.register(value_equals(postgresql.JSONB))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.HSTORE))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.JSON))
+@convert_sqlalchemy_type.register(column_type_eq(postgresql.JSONB))
 def convert_json_to_string(
     type_arg: Any,
     **kwargs,
@@ -419,8 +419,8 @@ def convert_json_to_string(
     return JSONString
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_utils.JSONType))
-@convert_sqlalchemy_type.register(value_equals(sqa_types.JSON))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_utils.JSONType))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.JSON))
 def convert_json_type_to_string(
     type_arg: Any,
     **kwargs,
@@ -428,7 +428,7 @@ def convert_json_type_to_string(
     return JSONString
 
 
-@convert_sqlalchemy_type.register(value_equals(sqa_types.Variant))
+@convert_sqlalchemy_type.register(column_type_eq(sqa_types.Variant))
 def convert_variant_to_impl_type(
     type_arg: sqa_types.Variant,
     column: Optional[Union[MapperProperty, hybrid_property]] = None,
@@ -446,7 +446,7 @@ def convert_variant_to_impl_type(
     )
 
 
-@convert_sqlalchemy_type.register(value_equals(Decimal))
+@convert_sqlalchemy_type.register(column_type_eq(Decimal))
 def convert_sqlalchemy_hybrid_property_type_decimal(type_arg: Any, **kwargs):
     # The reason Decimal should be serialized as a String is because this is a
     # base10 type used in things like money, and string allows it to not

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -247,8 +247,9 @@ def convert_sqlalchemy_type(
         return type_arg
 
     # No valid type found, warn and fall back to graphene.String
-    raise Exception(
-        "Don't know how to convert the SQLAlchemy field %s (%s, %s)"
+    raise TypeError(
+        "Don't know how to convert the SQLAlchemy field %s (%s, %s). "
+        "Please add a type converter or set the type manually using ORMField(type_=your_type)"
         % (column, column.__class__ or "no column provided", type_arg)
     )
 
@@ -562,6 +563,12 @@ def convert_sqlalchemy_hybrid_property_bare_str(type_arg: str, **kwargs):
 
 def convert_hybrid_property_return_type(hybrid_prop):
     # Grab the original method's return type annotations from inside the hybrid property
-    return_type_annotation = hybrid_prop.fget.__annotations__.get("return", str)
+    return_type_annotation = hybrid_prop.fget.__annotations__.get("return", None)
+    if not return_type_annotation:
+        raise TypeError(
+            "Cannot convert hybrid property type {} to a valid graphene type. "
+            "Please make sure to annotate the return type of the hybrid property or use the "
+            "type_ attribute of ORMField to set the type.".format(hybrid_prop)
+        )
 
     return convert_sqlalchemy_type(return_type_annotation)

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -553,7 +553,11 @@ def convert_sqlalchemy_hybrid_property_forwardref(type_arg: Any, **kwargs):
     def forward_reference_solver():
         model = registry_sqlalchemy_model_from_str(type_arg.__forward_arg__)
         if not model:
-            return graphene.String
+            raise TypeError(
+                "No model found in Registry for forward reference for type %s. "
+                "Only forward references to other SQLAlchemy Models mapped to "
+                "SQLAlchemyObjectTypes are allowed." % type_arg
+            )
         # Always fall back to string if no ForwardRef type found.
         return get_global_registry().get_type_for_model(model)
 
@@ -579,4 +583,4 @@ def convert_hybrid_property_return_type(hybrid_prop):
             "type_ attribute of ORMField to set the type.".format(hybrid_prop)
         )
 
-    return convert_sqlalchemy_type(return_type_annotation)
+    return convert_sqlalchemy_type(return_type_annotation, column=hybrid_prop)

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union, cast
 from sqlalchemy import types as sqa_types
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import DeclarativeMeta, interfaces, strategies
+from sqlalchemy.orm import interfaces, strategies
 
 import graphene
 from graphene.types.json import JSONString
@@ -19,6 +19,7 @@ from .fields import BatchSQLAlchemyConnectionField, default_connection_field_fac
 from .registry import Registry, get_global_registry
 from .resolvers import get_attr_resolver, get_custom_resolver
 from .utils import (
+    SQL_VERSION_HIGHER_EQUAL_THAN_1_4,
     DummyImport,
     column_type_eq,
     registry_sqlalchemy_model_from_str,
@@ -26,6 +27,12 @@ from .utils import (
     safe_issubclass,
     singledispatchbymatchfunction,
 )
+
+# Import path changed in 1.4
+if SQL_VERSION_HIGHER_EQUAL_THAN_1_4:
+    from sqlalchemy.orm import DeclarativeMeta
+else:
+    from sqlalchemy.ext.declarative import DeclarativeMeta
 
 # We just use MapperProperties for type hints, they don't exist in sqlalchemy < 1.4
 try:
@@ -237,7 +244,6 @@ def convert_sqlalchemy_type(  # noqa
     registry: Registry = None,
     **kwargs,
 ):
-
     # No valid type found, raise an error
 
     raise TypeError(

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -324,9 +324,11 @@ def convert_column_to_int_or_id(
     registry: Registry = None,
     **kwargs,
 ):
-    return (
-        graphene.ID if (column is not None) and column.primary_key else graphene.Int
-    )  # fixme drop the primary key processing in another pr
+    # fixme drop the primary key processing from here in another pr
+    if column is not None:
+        if getattr(column, "primary_key", False) is True:
+            return graphene.ID
+    return graphene.Int
 
 
 @convert_sqlalchemy_type.register(column_type_eq(sqa_types.Boolean))

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -8,7 +8,7 @@ from typing import Any, Optional, Union, cast
 from sqlalchemy import types as sqa_types
 from sqlalchemy.dialects import postgresql
 from sqlalchemy.ext.hybrid import hybrid_property
-from sqlalchemy.orm import MapperProperty, interfaces, strategies
+from sqlalchemy.orm import interfaces, strategies
 
 import graphene
 from graphene.types.json import JSONString
@@ -26,6 +26,13 @@ from .utils import (
     value_equals,
     value_equals_strict,
 )
+
+# We just use MapperProperties for type hints, they don't exist in sqlalchemy < 1.4
+try:
+    from sqlalchemy import MapperProperty
+except ImportError:
+    # sqlalchemy < 1.4
+    MapperProperty = Any
 
 try:
     from typing import ForwardRef

--- a/graphene_sqlalchemy/converter.py
+++ b/graphene_sqlalchemy/converter.py
@@ -239,7 +239,8 @@ def convert_sqlalchemy_type(
 ):
     registry_ = registry or get_global_registry()
     # Enable returning Models by getting the corresponding model from the registry
-    # ToDo do we need a Dynamic Type here?
+    # ToDo Move to a separate converter later, matching all sqlalchemy mapped
+    #  types and returning a dynamic
     existing_graphql_type = registry_.get_type_for_model(type_arg)
     if existing_graphql_type:
         return existing_graphql_type

--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -83,13 +83,13 @@ class Registry(object):
         return self._registry_sort_enums.get(obj_type)
 
     def register_union_type(
-        self, union: graphene.Union, obj_types: List[Type[graphene.ObjectType]]
+        self, union: Type[graphene.Union], obj_types: List[Type[graphene.ObjectType]]
     ):
-        if not isinstance(union, graphene.Union):
+        if not issubclass(union, graphene.Union):
             raise TypeError("Expected graphene.Union, but got: {!r}".format(union))
 
         for obj_type in obj_types:
-            if not isinstance(obj_type, type(graphene.ObjectType)):
+            if not issubclass(obj_type, graphene.ObjectType):
                 raise TypeError(
                     "Expected Graphene ObjectType, but got: {!r}".format(obj_type)
                 )

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -88,12 +88,12 @@ class Reporter(Base):
     favorite_article = relationship("Article", uselist=False, lazy="selectin")
 
     @hybrid_property
-    def hybrid_prop_with_doc(self):
+    def hybrid_prop_with_doc(self) -> str:
         """Docstring test"""
         return self.first_name
 
     @hybrid_property
-    def hybrid_prop(self):
+    def hybrid_prop(self) -> str:
         return self.first_name
 
     @hybrid_property
@@ -252,13 +252,6 @@ class ShoppingCart(Base):
     @hybrid_property
     def hybrid_prop_shopping_cart_item_list(self) -> List[ShoppingCartItem]:
         return [ShoppingCartItem(id=1), ShoppingCartItem(id=2)]
-
-    # Unsupported Type
-    # fixme move this somewhere else
-    #
-    # @hybrid_property
-    # def hybrid_prop_unsupported_type_tuple(self) -> Tuple[str, str]:
-    #     return "this will actually", "be a string"
 
     # Self-references
 

--- a/graphene_sqlalchemy/tests/models.py
+++ b/graphene_sqlalchemy/tests/models.py
@@ -4,7 +4,7 @@ import datetime
 import enum
 import uuid
 from decimal import Decimal
-from typing import List, Optional, Tuple
+from typing import List, Optional
 
 from sqlalchemy import (
     Column,
@@ -254,9 +254,11 @@ class ShoppingCart(Base):
         return [ShoppingCartItem(id=1), ShoppingCartItem(id=2)]
 
     # Unsupported Type
-    @hybrid_property
-    def hybrid_prop_unsupported_type_tuple(self) -> Tuple[str, str]:
-        return "this will actually", "be a string"
+    # fixme move this somewhere else
+    #
+    # @hybrid_property
+    # def hybrid_prop_unsupported_type_tuple(self) -> Tuple[str, str]:
+    #     return "this will actually", "be a string"
 
     # Self-references
 

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -20,6 +20,7 @@ from ..converter import (
     convert_sqlalchemy_composite,
     convert_sqlalchemy_hybrid_method,
     convert_sqlalchemy_relationship,
+    convert_sqlalchemy_type,
 )
 from ..fields import UnsortedSQLAlchemyConnectionField, default_connection_field_factory
 from ..registry import Registry, get_global_registry
@@ -166,6 +167,11 @@ def test_should_union_work_310():
     assert issubclass(field_type_1, graphene.Union)
     assert field_type_1._meta.types == [PetType, ShoppingCartType]
     assert field_type_1 is field_type_2
+
+
+def test_should_unknown_type_raise_error():
+    with pytest.raises(Exception):
+        converted_type = convert_sqlalchemy_type(ZeroDivisionError)  # noqa
 
 
 def test_should_datetime_convert_datetime():

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -138,6 +138,51 @@ def test_hybrid_prop_scalar_type():
     assert get_hybrid_property_type(hybrid_prop).type == graphene.String
 
 
+def test_hybrid_prop_not_mapped_to_graphene_type():
+    @hybrid_property
+    def hybrid_prop(self) -> ShoppingCartItem:
+        return "This shouldn't work"
+
+    with pytest.raises(TypeError, match=r"(.*)No model found in Registry for type(.*)"):
+        get_hybrid_property_type(hybrid_prop).type
+
+
+def test_hybrid_prop_mapped_to_graphene_type():
+    class ShoppingCartType(SQLAlchemyObjectType):
+        class Meta:
+            model = ShoppingCartItem
+
+    @hybrid_property
+    def hybrid_prop(self) -> ShoppingCartItem:
+        return "Dummy return value"
+
+    get_hybrid_property_type(hybrid_prop).type == ShoppingCartType
+
+
+def test_hybrid_prop_forward_ref_not_mapped_to_graphene_type():
+    @hybrid_property
+    def hybrid_prop(self) -> "ShoppingCartItem":
+        return "This shouldn't work"
+
+    with pytest.raises(
+        TypeError,
+        match=r"(.*)No model found in Registry for forward reference for type(.*)",
+    ):
+        get_hybrid_property_type(hybrid_prop).type
+
+
+def test_hybrid_prop_forward_ref_mapped_to_graphene_type():
+    class ShoppingCartType(SQLAlchemyObjectType):
+        class Meta:
+            model = ShoppingCartItem
+
+    @hybrid_property
+    def hybrid_prop(self) -> "ShoppingCartItem":
+        return "Dummy return value"
+
+    get_hybrid_property_type(hybrid_prop).type == ShoppingCartType
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="|-Style Unions are unsupported in python < 3.10"
 )

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -103,6 +103,22 @@ def test_hybrid_prop_no_type_annotation():
         get_hybrid_property_type(hybrid_prop)
 
 
+def test_hybrid_invalid_forward_reference():
+    class MyTypeNotInRegistry:
+        pass
+
+    @hybrid_property
+    def hybrid_prop(self) -> "MyTypeNotInRegistry":
+        return MyTypeNotInRegistry()
+
+    with pytest.raises(
+        TypeError,
+        match=r"(.*)Only forward references to other SQLAlchemy Models mapped to "
+        "SQLAlchemyObjectTypes are allowed.(.*)",
+    ):
+        get_hybrid_property_type(hybrid_prop).type
+
+
 def test_hybrid_prop_object_type():
     class MyObjectType(graphene.ObjectType):
         string = graphene.String()

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -103,6 +103,25 @@ def test_hybrid_prop_no_type_annotation():
         get_hybrid_property_type(hybrid_prop)
 
 
+def test_hybrid_prop_object_type():
+    class MyObjectType(graphene.ObjectType):
+        string = graphene.String()
+
+    @hybrid_property
+    def hybrid_prop(self) -> MyObjectType:
+        return MyObjectType()
+
+    assert get_hybrid_property_type(hybrid_prop).type == MyObjectType
+
+
+def test_hybrid_prop_scalar_type():
+    @hybrid_property
+    def hybrid_prop(self) -> graphene.String:
+        return "This should work"
+
+    assert get_hybrid_property_type(hybrid_prop).type == graphene.String
+
+
 @pytest.mark.skipif(
     sys.version_info < (3, 10), reason="|-Style Unions are unsupported in python < 3.10"
 )

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -163,7 +163,8 @@ def test_should_union_work_310():
     field_type_1 = get_hybrid_property_type(prop_method).type
     field_type_2 = get_hybrid_property_type(prop_method_2).type
 
-    assert isinstance(field_type_1, graphene.Union)
+    assert issubclass(field_type_1, graphene.Union)
+    assert field_type_1._meta.types == [PetType, ShoppingCartType]
     assert field_type_1 is field_type_2
 
 

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -131,10 +131,9 @@ def test_should_union_work():
     field_type_1 = get_hybrid_property_type(prop_method).type
     field_type_2 = get_hybrid_property_type(prop_method_2).type
 
-    assert isinstance(field_type_1, graphene.Union)
+    assert issubclass(field_type_1, graphene.Union)
+    assert field_type_1._meta.types == [PetType, ShoppingCartType]
     assert field_type_1 is field_type_2
-
-    # TODO verify types of the union
 
 
 @pytest.mark.skipif(
@@ -667,7 +666,6 @@ def test_sqlalchemy_hybrid_property_type_inference():
         ),
         "hybrid_prop_first_shopping_cart_item": ShoppingCartItemType,
         "hybrid_prop_shopping_cart_item_list": graphene.List(ShoppingCartItemType),
-        "hybrid_prop_unsupported_type_tuple": graphene.String,
         # Self Referential List
         "hybrid_prop_self_referential": ShoppingCartType,
         "hybrid_prop_self_referential_list": graphene.List(ShoppingCartType),

--- a/graphene_sqlalchemy/tests/test_converter.py
+++ b/graphene_sqlalchemy/tests/test_converter.py
@@ -1,6 +1,6 @@
 import enum
 import sys
-from typing import Dict, Union
+from typing import Dict, Tuple, Union
 
 import pytest
 import sqlalchemy_utils as sqa_utils
@@ -77,6 +77,30 @@ def test_hybrid_prop_int():
         return 42
 
     assert get_hybrid_property_type(prop_method).type == graphene.Int
+
+
+def test_hybrid_unknown_annotation():
+    @hybrid_property
+    def hybrid_prop(self):
+        return "This should fail"
+
+    with pytest.raises(
+        TypeError,
+        match=r"(.*)Please make sure to annotate the return type of the hybrid property or use the "
+        "type_ attribute of ORMField to set the type.(.*)",
+    ):
+        get_hybrid_property_type(hybrid_prop)
+
+
+def test_hybrid_prop_no_type_annotation():
+    @hybrid_property
+    def hybrid_prop(self) -> Tuple[str, str]:
+        return "This should Fail because", "we don't support Tuples in GQL"
+
+    with pytest.raises(
+        TypeError, match=r"(.*)Don't know how to convert the SQLAlchemy field(.*)"
+    ):
+        get_hybrid_property_type(hybrid_prop)
 
 
 @pytest.mark.skipif(

--- a/graphene_sqlalchemy/tests/test_registry.py
+++ b/graphene_sqlalchemy/tests/test_registry.py
@@ -142,7 +142,7 @@ def test_register_union():
             model = Reporter
 
     union_types = [PetType, ReporterType]
-    union = graphene.Union("ReporterPet", tuple(union_types))
+    union = graphene.Union.create_type("ReporterPet", types=tuple(union_types))
 
     reg.register_union_type(union, union_types)
 
@@ -155,7 +155,7 @@ def test_register_union_scalar():
     reg = Registry()
 
     union_types = [graphene.String, graphene.Int]
-    union = graphene.Union("StringInt", tuple(union_types))
+    union = graphene.Union.create_type("StringInt", types=union_types)
 
     re_err = r"Expected Graphene ObjectType, but got: .*String.*"
     with pytest.raises(TypeError, match=re_err):

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -196,18 +196,23 @@ class singledispatchbymatchfunction:
         # No match, using default.
         return self.default(*args, **kwargs)
 
-    def register(self, matcher_function: Callable[[Any], bool]):
-        def grab_function_from_outside(f):
-            self.registry[matcher_function] = f
-            return self
+    def register(self, matcher_function: Callable[[Any], bool], func=None):
+        if func is None:
+            return lambda f: self.register(matcher_function, f)
+        self.registry[matcher_function] = func
+        return func
 
-        return grab_function_from_outside
 
-
-def value_equals(value):
+def value_equals(value: Any) -> Callable[[Any], bool]:
     """A simple function that makes the equality based matcher functions for
     SingleDispatchByMatchFunction prettier"""
-    return lambda x: x == value
+    return lambda x: (x == value or type(x) is value)
+
+
+def value_equals_strict(value: Any) -> Callable[[Any], bool]:
+    """A simple function that makes the equality based matcher functions for
+    SingleDispatchByMatchFunction prettier"""
+    return lambda x: (x == value)
 
 
 def safe_isinstance(cls):

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -219,6 +219,16 @@ def safe_isinstance(cls):
     return safe_isinstance_checker
 
 
+def safe_issubclass(cls):
+    def safe_issubclass_checker(arg):
+        try:
+            return issubclass(arg, cls)
+        except TypeError:
+            pass
+
+    return safe_issubclass_checker
+
+
 def registry_sqlalchemy_model_from_str(model_name: str) -> Optional[Any]:
     from graphene_sqlalchemy.registry import get_global_registry
 

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -206,12 +206,6 @@ class singledispatchbymatchfunction:
 def value_equals(value: Any) -> Callable[[Any], bool]:
     """A simple function that makes the equality based matcher functions for
     SingleDispatchByMatchFunction prettier"""
-    return lambda x: (x == value or type(x) is value)
-
-
-def value_equals_strict(value: Any) -> Callable[[Any], bool]:
-    """A simple function that makes the equality based matcher functions for
-    SingleDispatchByMatchFunction prettier"""
     return lambda x: (x == value)
 
 

--- a/graphene_sqlalchemy/utils.py
+++ b/graphene_sqlalchemy/utils.py
@@ -203,7 +203,7 @@ class singledispatchbymatchfunction:
         return func
 
 
-def value_equals(value: Any) -> Callable[[Any], bool]:
+def column_type_eq(value: Any) -> Callable[[Any], bool]:
     """A simple function that makes the equality based matcher functions for
     SingleDispatchByMatchFunction prettier"""
     return lambda x: (x == value)


### PR DESCRIPTION
This PR refactors the type conversion system to use the same converters for all column types (column + hybrid). Previously, we had `convert_sqlalchemy_column` using `singledispatch` and `convert_sqlalchemy_hybrid_property_type` using a custom singledispatch-like solution to match column and hybrid property type(-hints) to their graphene equivalents. This implied having to maintain two separate type conversion systems with very similar functionality. This PR proposes merging the systems based on our custom singledispatch-style approach. This has several implications:

### Breaking Change: convert_sqlalchemy_type now uses a matcher function
Our custom matcher needs to be able to check more than just the type of a column. Some type hints like unions or optionals need further processing. To convert old singledispatch-style converters to the new converters, the column type has to be wrapped in our custom `value_equals` helper function:

```
# Before 
@convert_sqlalchemy_type.register(JSON)

# After
@convert_sqlalchemy_type.register(value_equals(JSON))
```
### Breaking Change: convert_sqlalchemy_type support for subtypes is dropped, each column type must be explicitly registered
Since we now use matcher functions, it doesn't make sense to check if any inherited types match the singledispatch converters, as they might interfere with other matchers. Because of that, all types must now be explicitly registered:

```
@convert_sqlalchemy_type.register(value_equals(MYColumnType))
def convert_my_type(column_type, **kwargs):
   return MyGrapheneType
```

See `converter.py` for more detailed examples.

### Breaking Change: The first argument to converter functions is always a type
Previously, both type and instances of types were passed to the converter. (`String` vs `String(30)`). If you need information from the instance, use `column.type` instead.  *Remember to check if `column` is present and not a `hybrid_property`*

#### Example:
```python
@convert_sqlalchemy_type.register(column_type_eq(sqa_types.ARRAY))
@convert_sqlalchemy_type.register(column_type_eq(postgresql.ARRAY))
def convert_array_to_list(
    type_arg: Any,
    column: Optional[Union[MapperProperty, hybrid_property]] = None,
    registry: Registry = None,
    **kwargs,
):
    if column is None or isinstance(column, hybrid_property):
        raise Exception("SQL-Array conversion requires a column")
    item_type = column.type.item_type
    if not isinstance(item_type, type):
        item_type = type(item_type)
    inner_type = convert_sqlalchemy_type(
        item_type, column=column, registry=registry, **kwargs
    )
    return graphene.List(
        init_array_list_recursive(inner_type, (column.type.dimensions or 1) - 1)
    )
```
### Breaking Change: convert_sqlalchemy_type's column and registry arguments must now be keyword arguments
To make additional support for type conversions possible, we converted all arguments to the converters to keyword arguments. It is not guaranteed for these to be present, so you should always check for existance of `column` or `registry` if you plan on using them. 
Since other arguments might be provided as well, make sure that `**kwargs` is present on your signature and that it is passed to any calls of nested type conversions (e.g. `List[JSON]` calls `convert_list`, then `convert_list` starts another conversion for the inner type)

### Breaking Change: The hybrid property default column type is no longer a string. If no matching column type was found, an exception will be raised.
We introduced warnings for the string fallback in `3.0.0b2` as a soft transition to the new system. Since we merged both conversion systems, it is impractical to have a fallback for all types. If you want to keep the old `string` types for your hybrids, please use:

```python
class MyType(SQLAlchemyObjectType):
    class Meta:
        model = MyModelWithHybrid
    myHybrid = ORMField(type_=graphene.String)
```