### PR TITLE
Fix installation instruction: '--pre' instead of '>=3'

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A [SQLAlchemy](http://www.sqlalchemy.org/) integration for [Graphene](http://gra
 For installing Graphene, just run this command in your shell.
 
 ```bash
-pip install "graphene-sqlalchemy>=3"
+pip install --pre "graphene-sqlalchemy"
 ```
 
 ## Examples


### PR DESCRIPTION
I didn't update version number as required by contrib guidelines, as this change affects only README.md, and doesn't change code behavior. Is it OK?

**About the change:**
Install instructions in the README.md fails with an error: „Could not find a version that satisfies the requirement graphene-sqlalchemy>=3“

This is because v3 is in beta. Therefore, installing with '--pre' fixes the problem.

Also, it's not a unique case — the same problem appears to be in `graphene-django`: https://github.com/graphql-python/graphene-django/issues/1288