### PR TITLE
chore: limit lint runs to master pushes and PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,6 +1,12 @@
 name: Lint
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - 'master'
+  pull_request:
+    branches:
+      - '*'
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - '*'
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
As tests were running twice per commit in PRs, so is linting. This change prevents that. 

Shouldn't make a difference so long as the default branch is protected from merging without a PR and people are using pre-commit.