### PR TITLE
fix: warnings in docs build

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -11,7 +11,7 @@ SQLAlchemyInterface
 
 ORMField
 --------------------
-.. autoclass:: graphene_sqlalchemy.fields.ORMField
+.. autoclass:: graphene_sqlalchemy.types.ORMField
 
 SQLAlchemyConnectionField
 -------------------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -178,7 +178,7 @@ html_theme_path = [sphinx_graphene_theme.get_html_theme_path()]
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # Add any extra paths that contain custom files (such as robots.txt or
 # .htaccess) here, relative to this directory. These files are copied

--- a/docs/inheritance.rst
+++ b/docs/inheritance.rst
@@ -1,9 +1,13 @@
 Inheritance Examples
 ====================
 
+
 Create interfaces from inheritance relationships
 ------------------------------------------------
-.. note:: If you're using `AsyncSession`, please check the section `Eager Loading & Using with AsyncSession`_.
+
+.. note::
+    If you're using `AsyncSession`, please check the chapter `Eager Loading & Using with AsyncSession`_.
+
 SQLAlchemy has excellent support for class inheritance hierarchies.
 These hierarchies can be represented in your GraphQL schema by means
 of interfaces_.  Much like ObjectTypes, Interfaces in
@@ -111,8 +115,10 @@ class to the Schema constructor via the `types=` argument:
 
 See also: `Graphene Interfaces <https://docs.graphene-python.org/en/latest/types/interfaces/>`_
 
+
 Eager Loading & Using with AsyncSession
 ----------------------------------------
+
 When querying the base type in multi-table inheritance or joined table inheritance, you can only directly refer to polymorphic fields when they are loaded eagerly.
 This restricting is in place because AsyncSessions don't allow implicit async operations such as the loads of the joined tables.
 To load the polymorphic fields eagerly, you can use the `with_polymorphic` attribute of the mapper args in the base model:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,3 @@
+sphinx
 # Docs template
 http://graphene-python.org/sphinx_graphene_theme.zip

--- a/docs/tips.rst
+++ b/docs/tips.rst
@@ -5,6 +5,7 @@ Tips
 Querying
 --------
 .. _querying:
+
 In order to make querying against the database work, there are two alternatives:
 
 -  Set the db session when you do the execution:

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -408,13 +408,15 @@ class SQLAlchemyObjectType(SQLAlchemyBase, ObjectType):
 
     Usage:
 
-        class MyModel(Base):
-            id = Column(Integer(), primary_key=True)
-            name = Column(String())
+        .. code-block:: python
 
-        class MyType(SQLAlchemyObjectType):
-            class Meta:
-                model = MyModel
+            class MyModel(Base):
+                id = Column(Integer(), primary_key=True)
+                name = Column(String())
+
+            class MyType(SQLAlchemyObjectType):
+                class Meta:
+                    model = MyModel
     """
 
     @classmethod
@@ -450,30 +452,32 @@ class SQLAlchemyInterface(SQLAlchemyBase, Interface):
 
     Usage (using joined table inheritance):
 
-        class MyBaseModel(Base):
-            id = Column(Integer(), primary_key=True)
-            type = Column(String())
-            name = Column(String())
+        .. code-block:: python
 
-        __mapper_args__ = {
-            "polymorphic_on": type,
-        }
+            class MyBaseModel(Base):
+                id = Column(Integer(), primary_key=True)
+                type = Column(String())
+                name = Column(String())
 
-        class MyChildModel(Base):
-            date = Column(Date())
+            __mapper_args__ = {
+                "polymorphic_on": type,
+            }
 
-        __mapper_args__ = {
-            "polymorphic_identity": "child",
-        }
+            class MyChildModel(Base):
+                date = Column(Date())
 
-        class MyBaseType(SQLAlchemyInterface):
-            class Meta:
-                model = MyBaseModel
+            __mapper_args__ = {
+                "polymorphic_identity": "child",
+            }
 
-        class MyChildType(SQLAlchemyObjectType):
-            class Meta:
-                model = MyChildModel
-                interfaces = (MyBaseType,)
+            class MyBaseType(SQLAlchemyInterface):
+                class Meta:
+                    model = MyBaseModel
+
+            class MyChildType(SQLAlchemyObjectType):
+                class Meta:
+                    model = MyChildModel
+                    interfaces = (MyBaseType,)
     """
 
     @classmethod


### PR DESCRIPTION
Small fixes to docs to eliminate compile warnings.
As of now, the custom sphinx theme does not properly format ``note`` blocks. Might be something to take a look at in the future.