### PR TITLE
fix: set README content_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ schema = graphene.Schema(query=Query)
 
 ### Full Examples
 
-To learn more check out the following [examples](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/examples/):
+To learn more check out the following [examples](https://github.com/graphql-python/graphene-sqlalchemy/tree/master/examples/):
 
-- [Flask SQLAlchemy example](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/examples/flask_sqlalchemy)
-- [Nameko SQLAlchemy example](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/examples/nameko_sqlalchemy)
+- [Flask SQLAlchemy example](https://github.com/graphql-python/graphene-sqlalchemy/tree/master/examples/flask_sqlalchemy)
+- [Nameko SQLAlchemy example](https://github.com/graphql-python/graphene-sqlalchemy/tree/master/examples/nameko_sqlalchemy)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -109,11 +109,11 @@ schema = graphene.Schema(query=Query)
 
 ### Full Examples
 
-To learn more check out the following [examples](examples/):
+To learn more check out the following [examples](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/examples/):
 
-- [Flask SQLAlchemy example](examples/flask_sqlalchemy)
-- [Nameko SQLAlchemy example](examples/nameko_sqlalchemy)
+- [Flask SQLAlchemy example](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/examples/flask_sqlalchemy)
+- [Nameko SQLAlchemy example](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/examples/nameko_sqlalchemy)
 
 ## Contributing
 
-See [CONTRIBUTING.md](/CONTRIBUTING.md)
+See [CONTRIBUTING.md](https://github.com/graphql-python/graphene-sqlalchemy/blob/master/CONTRIBUTING.md)

--- a/setup.py
+++ b/setup.py
@@ -35,6 +35,7 @@ setup(
     version=version,
     description="Graphene SQLAlchemy integration",
     long_description=open("README.md").read(),
+    long_description_content_type="text/markdown",
     url="https://github.com/graphql-python/graphene-sqlalchemy",
     project_urls={
         "Documentation": "https://docs.graphene-python.org/projects/sqlalchemy/en/latest",


### PR DESCRIPTION
PyPI requires content_type to be set for markdown. Also, use absolute links in README for PyPI