### PR TITLE
Automatic sort argument for SQLAlchemyInterface

### DIFF
--- a/graphene_sqlalchemy/registry.py
+++ b/graphene_sqlalchemy/registry.py
@@ -95,15 +95,10 @@ class Registry(object):
         return self._registry_enums.get(sa_enum)
 
     def register_sort_enum(self, obj_type, sort_enum: Enum):
+        from .types import SQLAlchemyBase
 
-        from .types import SQLAlchemyObjectType
-
-        if not isinstance(obj_type, type) or not issubclass(
-            obj_type, SQLAlchemyObjectType
-        ):
-            raise TypeError(
-                "Expected SQLAlchemyObjectType, but got: {!r}".format(obj_type)
-            )
+        if not isinstance(obj_type, type) or not issubclass(obj_type, SQLAlchemyBase):
+            raise TypeError("Expected SQLAlchemyBase, but got: {!r}".format(obj_type))
         if not isinstance(sort_enum, type(Enum)):
             raise TypeError("Expected Graphene Enum, but got: {!r}".format(sort_enum))
         self._registry_sort_enums[obj_type] = sort_enum

--- a/graphene_sqlalchemy/tests/test_registry.py
+++ b/graphene_sqlalchemy/tests/test_registry.py
@@ -120,7 +120,7 @@ def test_register_sort_enum_incorrect_types():
         [("ID", EnumValue("id", Pet.id)), ("NAME", EnumValue("name", Pet.name))],
     )
 
-    re_err = r"Expected SQLAlchemyObjectType, but got: .*PetSort.*"
+    re_err = r"Expected SQLAlchemyBase, but got: .*PetSort.*"
     with pytest.raises(TypeError, match=re_err):
         reg.register_sort_enum(sort_enum, sort_enum)
 


### PR DESCRIPTION
When using SQLAlchemyConnectionField with a SQLAlchemyInterface to get a polymorphic connection, one has to set the sort argument to None to disable automatic sort enum generation. However, the type check in register_sort_enum is too strict, and being an instance of SQLAlchemyBase seems to be sufficient for the code to work.

Tests run with Python 3.8 and 3.12.