### PR TITLE
Feat: make new filters feature optional

### DIFF
--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -440,6 +440,7 @@ class SQLAlchemyBase(BaseType):
         batching=False,
         connection_field_factory=None,
         _meta=None,
+        create_filters=True,
         **options,
     ):
         # We always want to bypass this hook unless we're defining a concrete
@@ -474,7 +475,7 @@ class SQLAlchemyBase(BaseType):
             only_fields=only_fields,
             exclude_fields=exclude_fields,
             batching=batching,
-            create_filters=True,
+            create_filters=create_filters,
             connection_field_factory=connection_field_factory,
         )
 


### PR DESCRIPTION
We have developed our own filtering system on top of `graphene-sqlalchemy` previously and have no need for automatic generation of filters on connections and the currently only clutter up our schema. I haven't found a way to disable them in docs, however, after walking through the code, it seemed to me that the option is there - it's just hardcoded to be always `True`. Was there a reason for that, or maybe an oversight?

This is my first time opening a public pull request, so I'm open to feedback and pointers! Thanks a lot for your work!