### PR TITLE
Do not create filter class if create_filters is False

### DIFF
--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -513,7 +513,7 @@ class SQLAlchemyBase(BaseType):
             _meta.fields = sqla_fields
 
         # Save Generated filter class in Meta Class
-        if not _meta.filter_class:
+        if create_filters and not _meta.filter_class:
             # Map graphene fields to filters
             # TODO we might need to pass the ORMFields containing the SQLAlchemy models
             #  to the scalar filters here (to generate expressions from the model)


### PR DESCRIPTION
### Issue
The Filter classes are being created although `create_filters` is `False`.

For example:
```gql
input PetTypeFilter {
  and: [PetTypeFilter]
  or: [PetTypeFilter]
}
```


### Solution
Check `create_filters` before creating the Filter class.

### Related
https://github.com/graphql-python/graphene-sqlalchemy/pull/414