### PR TITLE
Remove transitive dependency greenlet from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,6 @@ tests_require = [
     "pytest-benchmark>=3.4.0,<4.0",
     "aiosqlite>=0.17.0",
     "nest-asyncio",
-    "greenlet",
 ]
 
 setup(


### PR DESCRIPTION
As part of our ongoing research on Python dependency management we noticed a potential improvement in your project’s dependency management.

Specifically, the transitive dependency `greenlet` from `SQLAlchemy` is specified as a requirement in the `setup.py`, when in reality it is not needed.

This PR removes it from requirements.txt to let pip manage it automatically, which helps keeping the dependency list clean.

Hope this is helpful!

Best regards