### PR TITLE
Handle object retrieval with composite primary keys

### DIFF
--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -607,11 +607,11 @@ class SQLAlchemyBase(BaseType):
             return None
 
     def resolve_id(self, info):
-        # graphene_type = info.parent_type.graphene_type
+        graphene_type = info.parent_type.graphene_type
         keys = self.__mapper__.primary_key_from_instance(self)
 
         try:
-            return self.serializer.serialize(keys if len(keys) > 1 else keys[0])
+            return graphene_type.serializer.serialize(keys)
 
         except Exception as e:
             raise ValueError(f"Non-serializable primary key: {e}") from e

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -1,4 +1,5 @@
 import inspect
+import json
 import logging
 import warnings
 from collections import OrderedDict
@@ -557,9 +558,15 @@ class SQLAlchemyBase(BaseType):
 
     @classmethod
     def get_node(cls, info, id):
+        try:
+            key = json.loads(id)
+
+        except json.decoder.JSONDecodeError:
+            return None
+
         if not SQL_VERSION_HIGHER_EQUAL_THAN_1_4:
             try:
-                return cls.get_query(info).get(id)
+                return cls.get_query(info).get(key)
             except NoResultFound:
                 return None
 
@@ -571,14 +578,14 @@ class SQLAlchemyBase(BaseType):
 
             return get_result()
         try:
-            return cls.get_query(info).get(id)
+            return cls.get_query(info).get(key)
         except NoResultFound:
             return None
 
     def resolve_id(self, info):
         # graphene_type = info.parent_type.graphene_type
         keys = self.__mapper__.primary_key_from_instance(self)
-        return str(tuple(keys)) if len(keys) > 1 else keys[0]
+        return json.dumps(keys if len(keys) > 1 else keys[0])
 
     @classmethod
     def enum_for_field(cls, field_name):

--- a/graphene_sqlalchemy/types.py
+++ b/graphene_sqlalchemy/types.py
@@ -1,5 +1,4 @@
 import inspect
-import json
 import logging
 import warnings
 from collections import OrderedDict
@@ -419,6 +418,28 @@ def construct_fields_and_filters(
     return fields, filters
 
 
+class SQLAlchemyPrimaryKeySerializer(object):
+    """
+    Serializes/unserializes primary keys
+    """
+
+    DEFAULT = None
+
+    def __init__(self, serialize, deserialize):
+        self.serialize = serialize
+        self.deserialize = deserialize
+
+    @classmethod
+    def default(cls):
+        if cls.DEFAULT is None:
+            cls.DEFAULT = cls(
+                serialize=lambda keys: str(tuple(keys)) if len(keys) > 1 else keys[0],
+                deserialize=lambda id: id,
+            )
+
+        return cls.DEFAULT
+
+
 class SQLAlchemyBase(BaseType):
     """
     This class contains initialization code that is common to both ObjectTypes
@@ -442,6 +463,7 @@ class SQLAlchemyBase(BaseType):
         connection_field_factory=None,
         _meta=None,
         create_filters=True,
+        serializer=None,
         **options,
     ):
         # We always want to bypass this hook unless we're defining a concrete
@@ -531,6 +553,12 @@ class SQLAlchemyBase(BaseType):
 
         cls.connection = connection  # Public way to get the connection
 
+        if serializer is None:
+            cls.serializer = SQLAlchemyPrimaryKeySerializer.default()
+
+        else:
+            cls.serializer = serializer
+
         super(SQLAlchemyBase, cls).__init_subclass_with_meta__(
             _meta=_meta, interfaces=interfaces, **options
         )
@@ -558,11 +586,7 @@ class SQLAlchemyBase(BaseType):
 
     @classmethod
     def get_node(cls, info, id):
-        try:
-            key = json.loads(id)
-
-        except json.decoder.JSONDecodeError:
-            return None
+        key = cls.serializer.deserialize(id)
 
         if not SQL_VERSION_HIGHER_EQUAL_THAN_1_4:
             try:
@@ -574,7 +598,7 @@ class SQLAlchemyBase(BaseType):
         if isinstance(session, AsyncSession):
 
             async def get_result() -> Any:
-                return await session.get(cls._meta.model, id)
+                return await session.get(cls._meta.model, key)
 
             return get_result()
         try:
@@ -585,7 +609,12 @@ class SQLAlchemyBase(BaseType):
     def resolve_id(self, info):
         # graphene_type = info.parent_type.graphene_type
         keys = self.__mapper__.primary_key_from_instance(self)
-        return json.dumps(keys if len(keys) > 1 else keys[0])
+
+        try:
+            return self.serializer.serialize(keys if len(keys) > 1 else keys[0])
+
+        except Exception as e:
+            raise ValueError(f"Non-serializable primary key: {e}") from e
 
     @classmethod
     def enum_for_field(cls, field_name):


### PR DESCRIPTION
In the current implementation, `SQLAchemyBase.resolve_id` uses simple string conversion to convert object primary keys into string format, and `SQLAlchemyBase.get_node` passes the obtained key to a SQLAlchemy session to retrieve the object. However, this does not work for composite primary keys, as the string would first need to be converted back to a tuple. While this can be done with `eval`, this would be a security hole, since it would allow execution of arbitrary code, and ids are normally received as untrusted output.

The simplest and relatively general solution for the above would be to use the `json` module to serialize and deserialize the keys. However, not all allowed primary keys are json-serializable (e.g. `DATETIME`), so additional functionality may be required for a general case.

Instead of trying to provide a general solution for the above, the patch abstracts serialization of primary keys to a class attribute that can be configured based on the needs of the SQLAlchemy schema on a per-table basis. Schemas that do not contain tables with composite keys can continue to use the current implementation, which is provided as default.

As an example, to handle classes with json-serializable composite primary keys, the following configuration would be necessary:
```
import json
from graphene_sqlalchemy.types import SQLAlchemyObjectType, SQLAlchemyPrimaryKeySerializer

serializer = SQLAlchemyPrimaryKeySerializer(
    serialize=json.dumps,
    deserialize=json.loads, # this could be replaced with a wrapper that converts json.decoder.JSONDecodeError to ValueError
)  

...

class MyGrapheneClass(SQLAlchemyObjectType):
    class Meta(object):
        model=MySQLAlchemyModel
        interfaces=(Node,)
        serializer=serializer
```

I am open to suggestions on code restructuring, and will add tests to exercise the functionality.